### PR TITLE
Added support for animated round corners modifier

### DIFF
--- a/Lottie-Windows.sln
+++ b/Lottie-Windows.sln
@@ -131,6 +131,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Issues", "Issues", "{07D6DF
 		source\Issues\LT0040.md = source\Issues\LT0040.md
 		source\Issues\LT0041.md = source\Issues\LT0041.md
 		source\Issues\LT0042.md = source\Issues\LT0042.md
+		source\Issues\LT0043.md = source\Issues\LT0043.md
 		source\Issues\LV0001.md = source\Issues\LV0001.md
 		source\Issues\LV0002.md = source\Issues\LV0002.md
 		source\Issues\LV0003.md = source\Issues\LV0003.md

--- a/LottieGen/LottieGen.sln
+++ b/LottieGen/LottieGen.sln
@@ -86,6 +86,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Issues", "Issues", "{BDB88D
 		..\source\Issues\LT0040.md = ..\source\Issues\LT0040.md
 		..\source\Issues\LT0041.md = ..\source\Issues\LT0041.md
 		..\source\Issues\LT0042.md = ..\source\Issues\LT0042.md
+		..\source\Issues\LT0043.md = ..\source\Issues\LT0043.md
 		..\source\Issues\LV0001.md = ..\source\Issues\LV0001.md
 		..\source\Issues\LV0002.md = ..\source\Issues\LV0002.md
 		..\source\Issues\LV0003.md = ..\source\Issues\LV0003.md

--- a/source/Issues/LT0016.md
+++ b/source/Issues/LT0016.md
@@ -6,7 +6,7 @@
 The Lottie file specifies round corners on a path. This is not fully supported by Lottie-Windows. 
 It works correctly if the radius and shape path are not animated. If both radius and shape path 
 are animated, the round corner modifier will not be applied at all, otherwise if only one of them 
-is animated Lottie-Windows will try to generate an aimation but it is not guaranteed to look exactly 
+is animated Lottie-Windows will try to generate an animation but it is not guaranteed to look exactly 
 the same as in After Effects.
 
 ## Remarks

--- a/source/Issues/LT0016.md
+++ b/source/Issues/LT0016.md
@@ -1,9 +1,13 @@
-﻿[comment]: # (name:PathWithRoundCornersIsNotSupported)
-[comment]: # (text:Path with round corners is not supported.)
+﻿[comment]: # (name:PathWithRoundCornersIsNotFullySupported)
+[comment]: # (text:Path with round corners is not fully supported.)
 
 # Lottie-Windows Warning LT0016
 
-The Lottie file specifies round corners on a path. This is not currently supported by Lottie-Windows.
+The Lottie file specifies round corners on a path. This is not fully supported by Lottie-Windows. 
+It works correctly if the radius and shape path are not animated. If both radius and shape path 
+are animated, the round corner modifier will not be applied at all, otherwise if only one of them 
+is animated Lottie-Windows will try to generate an aimation but it is not guaranteed to look exactly 
+the same as in After Effects.
 
 ## Remarks
 If support for this feature is important for your scenario please provide feedback

--- a/source/Issues/LT0016.md
+++ b/source/Issues/LT0016.md
@@ -1,13 +1,9 @@
-﻿[comment]: # (name:PathWithRoundCornersIsNotFullySupported)
-[comment]: # (text:Path with round corners is not fully supported.)
+﻿[comment]: # (name:PathWithRoundCornersIsNotSupported)
+[comment]: # (text:Path with round corners is not supported.)
 
 # Lottie-Windows Warning LT0016
 
-The Lottie file specifies round corners on a path. This is not fully supported by Lottie-Windows. 
-It works correctly if the radius and shape path are not animated. If both radius and shape path 
-are animated, the round corner modifier will not be applied at all, otherwise if only one of them 
-is animated Lottie-Windows will try to generate an animation but it is not guaranteed to look exactly 
-the same as in After Effects.
+The Lottie file specifies round corners on a path. This is not currently supported by Lottie-Windows.
 
 ## Remarks
 If support for this feature is important for your scenario please provide feedback

--- a/source/Issues/LT0043.md
+++ b/source/Issues/LT0043.md
@@ -1,0 +1,19 @@
+[comment]: # (name:PathWithRoundCornersIsNotFullySupported)
+[comment]: # (text:Path with round corners is not fully supported.)
+
+# Lottie-Windows Warning LT0043
+
+The Lottie file specifies round corners on a path. This is not fully supported by Lottie-Windows. 
+It works correctly if the radius and shape path are not animated. If both radius and shape path 
+are animated, the round corner modifier will not be applied at all, otherwise if only one of them 
+is animated Lottie-Windows will try to generate an animation but it is not guaranteed to look exactly 
+the same as in After Effects.
+
+## Remarks
+If support for this feature is important for your scenario please provide feedback
+by raising it as an issue [here](https://github.com/windows-toolkit/Lottie-Windows/issues).
+
+## Resources
+
+* [Lottie-Windows repository](https://aka.ms/lottie)
+* [Questions and feedback via Github](https://github.com/windows-toolkit/Lottie-Windows/issues)

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // so that currently processed segment can create rounded corner using this point, and pass new point
         // to the next segment, so that it can create next rounded corner and so on.
         //
-        // Use optimizeNumberOfPoints = false if you need to keep the number of points constant, it can bee needed
+        // Use optimizeNumberOfPoints = false if you need to keep the number of points constant, it can be needed
         // for animated path.
         static PathGeometry MakeRoundCorners(PathGeometry pathGeometry, double radius, bool optimizeNumberOfPoints = true)
         {
@@ -566,11 +566,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                         }
                         else
                         {
-                            const double epsilon = 1e-6;
+                            float halfPlusEpsilon = Float32.NextLargerThan(0.5f);
+                            float halfMinusEpsilon = 1 - halfPlusEpsilon;
 
                             // Generate two points instead of one, but place them close to each other.
-                            point0 = (segment.ControlPoint0 * (0.5 + epsilon)) + (segment.ControlPoint3 * (0.5 - epsilon));
-                            point1 = (segment.ControlPoint0 * (0.5 - epsilon)) + (segment.ControlPoint3 * (0.5 + epsilon));
+                            point0 = (segment.ControlPoint0 * halfPlusEpsilon) + (segment.ControlPoint3 * halfMinusEpsilon);
+                            point1 = (segment.ControlPoint0 * halfMinusEpsilon) + (segment.ControlPoint3 * halfPlusEpsilon);
                         }
                     }
 

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -475,23 +475,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return new BezierSegment(cp0, cp0 + ((cp1 - cp0) * 0.55), cp2 + ((cp1 - cp2) * 0.55), cp2);
         }
 
-        // The way this function works is it detects if two segments form a corner (if they do not have smooth connection)
-        // Then it duplicates this point (shared by two segments) and moves newly generated points in different directions
-        // for "radius" pixels along the segment.
-        // After that we are joining both new points with a bezier curve to make the corner look rounded.
-        //
-        // There are 3 possible cases:
-        // 1. When the segment is curved from both sides, then we can just keep it as it is
-        // 2. When the segment is not curved from both sides, then we can make two rounded corners, from both ends.
-        // 3. When the segment curved from one side (begin or end) we are making only one rounded corner.
-        //
-        // In order to make a rounded corner we also need two points on segments next to the current segment.
-        // In this algortihm we are processing segments one by one, and passing one point from one segment to another,
-        // so that currently processed segment can create rounded corner using this point, and pass new point
-        // to the next segment, so that it can create next rounded corner and so on.
-        //
-        // Use optimizeNumberOfPoints = false if you need to keep the number of points constant, it can be needed
-        // for animated path.
+        /// <summary>
+        /// The way this function works is it detects if two segments form a corner (if they do not have smooth connection)
+        /// Then it duplicates this point (shared by two segments) and moves newly generated points in different directions
+        /// for "radius" pixels along the segment.
+        /// After that we are joining both new points with a bezier curve to make the corner look rounded.
+        ///
+        /// There are 3 possible cases:
+        /// 1. When the segment is curved from both sides, then we can just keep it as it is
+        /// 2. When the segment is not curved from both sides, then we can make two rounded corners, from both ends.
+        /// 3. When the segment curved from one side (begin or end) we are making only one rounded corner.
+        ///
+        /// In order to make a rounded corner we also need two points on segments next to the current segment.
+        /// In this algortihm we are processing segments one by one, and passing one point from one segment to another,
+        /// so that currently processed segment can create rounded corner using this point, and pass new point
+        /// to the next segment, so that it can create next rounded corner and so on.
+        /// </summary>
+        /// <param name="pathGeometry">Path.</param>
+        /// <param name="radius">Radius of corners.</param>
+        /// <param name="optimizeNumberOfPoints">Use optimizeNumberOfPoints = false if you need to keep the number of points constant,
+        /// it can be needed for animated path.</param>
         static PathGeometry MakeRoundCorners(PathGeometry pathGeometry, double radius, bool optimizeNumberOfPoints = true)
         {
             // There is no corners if we have less than two segments.
@@ -562,6 +565,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     {
                         if (optimizeNumberOfPoints)
                         {
+                            // Middle of the segment (ControlPoint0; ControlPoint3)
                             point0 = point1 = (segment.ControlPoint0 + segment.ControlPoint3) * 0.5;
                         }
                         else
@@ -570,6 +574,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             float halfMinusEpsilon = 1 - halfPlusEpsilon;
 
                             // Generate two points instead of one, but place them close to each other.
+                            // These two points are placed on the segment (ControlPoint0; ControlPoint3)
+                            // Almost in the middle but point0 is a bit closer to the ControlPoint0 and
+                            // point1 is a bit closer po ControlPoint3.
                             point0 = (segment.ControlPoint0 * halfPlusEpsilon) + (segment.ControlPoint3 * halfMinusEpsilon);
                             point1 = (segment.ControlPoint0 * halfMinusEpsilon) + (segment.ControlPoint3 * halfPlusEpsilon);
                         }

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -183,8 +183,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                                 paths.Add(Optimizer.OptimizePath(context, (Path)stack.Pop()));
                             }
 
-                            CheckForRoundCornersOnPath(context);
-
                             if (paths.Count == 1)
                             {
                                 // There's a single path.
@@ -192,6 +190,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             }
                             else
                             {
+                                // TODO: add support for round corners for multiple paths. I didn't find a way to generate
+                                // AE animation wth multiple paths on the same shape.
+                                CheckForRoundCornersOnPath(context);
+
                                 // There are multiple paths. They need to be grouped.
                                 container.Shapes.Add(Paths.TranslatePathGroupContent(context, paths));
                             }
@@ -631,8 +633,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         {
             if (!Optimizer.TrimAnimatable(context, context.RoundCorners.Radius).IsAlways(0))
             {
-                // TODO - can round corners be implemented by composing cubic Beziers?
-                context.Issues.PathWithRoundCornersIsNotSupported();
+                context.Issues.PathWithRoundCornersIsNotFullySupported();
             }
         }
 

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                             else
                             {
                                 // TODO: add support for round corners for multiple paths. I didn't find a way to generate
-                                // AE animation wth multiple paths on the same shape.
+                                // AE animation with multiple paths on the same shape.
                                 CheckForRoundCornersOnPath(context);
 
                                 // There are multiple paths. They need to be grouped.

--- a/source/LottieToWinComp/TranslationIssues.cs
+++ b/source/LottieToWinComp/TranslationIssues.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // LT0015 has been deprecated.
         // Was: Opacity and color animated at the same time is not supported.
 
-        internal void PathWithRoundCornersIsNotFullySupported() => Report("LT0016", "Path with round corners is not fully supported.");
+        internal void PathWithRoundCornersIsNotSupported() => Report("LT0016", "Path with round corners is not supported.");
 
         internal void PolystarIsNotSupported() => Report("LT0017", "Polystar is not supported.");
 
@@ -121,6 +121,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal void AnimatedLayerEffectParameters(string layerEffectType) => Report("LT0041", $"Animated parameters on {layerEffectType} effect are not supported.");
 
         internal void UnsupportedLayerEffectParameter(string layerEffectType, string parameterName, string value) => Report("LT0042", $"Layer effects of type {layerEffectType} do not support {parameterName} values of {value}.");
+
+        internal void PathWithRoundCornersIsNotFullySupported() => Report("LT0043", "Using a path with rounded corners can lead to inaccurate results.");
 
         void Report(string code, string description)
         {

--- a/source/LottieToWinComp/TranslationIssues.cs
+++ b/source/LottieToWinComp/TranslationIssues.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         // LT0015 has been deprecated.
         // Was: Opacity and color animated at the same time is not supported.
 
-        internal void PathWithRoundCornersIsNotSupported() => Report("LT0016", "Path with round corners is not supported.");
+        internal void PathWithRoundCornersIsNotFullySupported() => Report("LT0016", "Path with round corners is not fully supported.");
 
         internal void PolystarIsNotSupported() => Report("LT0017", "Polystar is not supported.");
 


### PR DESCRIPTION
In previous PR I added basic support for AE's "Round Corner" modifier but without animations. In this PR I added approximation* of animated version of this modifier. 

*We can not animate it 100% perfect as in After Effects, because in after effects they are applying this modifier to the path after interpolation happened, but in our case we can't do that since Composition layer do not support this modifier directly, so instead we are applying this modifier to each keyframe and then Composition interpolates between these kayframes. But in most cases, it looks indistinguishable from After Effects.

- Radius animated:
<img src="https://user-images.githubusercontent.com/83784664/123493724-2e34e900-d5d2-11eb-9a78-892aeadc00dc.gif" width="330px">

- Path animated:
<img src="https://user-images.githubusercontent.com/83784664/123493732-2ffeac80-d5d2-11eb-89d4-feb6ca77827b.gif" width="330px">
