### PR TITLE
Translate shape as a separate visual with child if it has animated opacity

### DIFF
--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -646,8 +646,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // Otherwise we should use extra parent Visual (GetVisualRoot).
             //
             // Note: We can apply Masks and effects only to Visual node.
-            // Also we can reduce number of expression animations if we apply opacity dorectly to visual node
-            // instad of pushing it down to color fill that will produce color expression animation.
+            // Also we can reduce number of expression animations if we apply opacity directly to visual node
+            // instead of pushing it down to color fill that will produce color expression animation.
             internal override bool IsShape =>
                 !_context.Layer.Masks.Any() &&
                 _context.Effects.DropShadowEffect is null &&

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -644,6 +644,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             // Indicates if we can translate shape layer as a single composition shape (GetShapeRoot).
             // Otherwise we should use extra parent Visual (GetVisualRoot).
+            //
+            // Note: We can apply Masks and effects only to Visual node.
+            // Also we can reduce number of expression animations if we apply opacity dorectly to visual node
+            // instad of pushing it down to color fill that will produce color expression animation.
             internal override bool IsShape =>
                 !_context.Layer.Masks.Any() &&
                 _context.Effects.DropShadowEffect is null &&

--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -642,10 +642,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 _context = context;
             }
 
+            // Indicates if we can translate shape layer as a single composition shape (GetShapeRoot).
+            // Otherwise we should use extra parent Visual (GetVisualRoot).
             internal override bool IsShape =>
                 !_context.Layer.Masks.Any() &&
                 _context.Effects.DropShadowEffect is null &&
-                _context.Effects.GaussianBlurEffect is null;
+                _context.Effects.GaussianBlurEffect is null &&
+                _context.Layer.Transform.Opacity.IsAlways(Opacity.Opaque);
 
             internal override CompositionShape? GetShapeRoot(TranslationContext context)
             {
@@ -668,6 +671,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 // Update the opacity from the transform. This is necessary to push the opacity
                 // to the leaves (because CompositionShape does not support opacity).
+                // Note: this is no longer used because we will not call GetShapeRoot if layer transform has
+                // animated opacity, instead we will call GetVisualRoot. But let's keep it here
+                // just in case we will change the logic of IsShape flag.
                 shapeContext.UpdateOpacityFromTransform(_context, _context.Layer.Transform);
                 contentsNode.Shapes.Add(TranslateShapeLayerContents(shapeContext, _context.Layer.Contents));
 


### PR DESCRIPTION
Previously if shape layer had animated or non-100% opacity it generated color expression animation (`"ColorRGB(my.Opacity, r, g, b)"`). Instead of that we can create separate visual with one child - this shape layer, and then animate opacity of the visual. We already have this logic for masks and effects so I just added another condition.