### PR TITLE
Added more merge optimizer options and moved optimizer call for LottieViewer

### DIFF
--- a/source/Lottie/Loader.cs
+++ b/source/Lottie/Loader.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Toolkit.Uwp.UI.Lottie.CompMetadata;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
+using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp;
 using Windows.Foundation.Metadata;
@@ -83,6 +84,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
                             jsonStream,
                             LottieCompositionReader.Options.IgnoreMatchNames,
                             out var readerIssues);
+
+                    if (lottieComposition is not null)
+                    {
+                        lottieComposition = LottieMergeOptimizer.Optimize(lottieComposition);
+                    }
 
                     if (diagnostics is not null)
                     {

--- a/source/LottieData/Optimization/Experimental/MergeHelper.cs
+++ b/source/LottieData/Optimization/Experimental/MergeHelper.cs
@@ -584,26 +584,26 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Optimization
 
             switch (a.ContentType)
             {
+                case ShapeContentType.Ellipse:
+                    return MergeResult<ShapeLayerContent>.From(MergeEllipses((Ellipse)a, aRange, (Ellipse)b, bRange));
                 case ShapeContentType.Group:
                     return MergeResult<ShapeLayerContent>.From(MergeShapeGroup((ShapeGroup)a, aRange, (ShapeGroup)b, bRange));
+                case ShapeContentType.LinearGradientFill:
+                    return MergeResult<ShapeLayerContent>.From(MergeLinearGradientFills((LinearGradientFill)a, aRange, (LinearGradientFill)b, bRange));
                 case ShapeContentType.Path:
                     return MergeResult<ShapeLayerContent>.From(MergePaths((Path)a, aRange, (Path)b, bRange));
-                case ShapeContentType.TrimPath:
-                    return MergeResult<ShapeLayerContent>.From(MergeTrimPaths((TrimPath)a, aRange, (TrimPath)b, bRange));
                 case ShapeContentType.Rectangle:
                     return MergeResult<ShapeLayerContent>.From(MergeRectangles((Rectangle)a, aRange, (Rectangle)b, bRange));
                 case ShapeContentType.RoundCorners:
                     return MergeResult<ShapeLayerContent>.From(MergeRoundCorners((RoundCorners)a, aRange, (RoundCorners)b, bRange));
-                case ShapeContentType.Ellipse:
-                    return MergeResult<ShapeLayerContent>.From(MergeEllipses((Ellipse)a, aRange, (Ellipse)b, bRange));
-                case ShapeContentType.LinearGradientFill:
-                    return MergeResult<ShapeLayerContent>.From(MergeLinearGradientFills((LinearGradientFill)a, aRange, (LinearGradientFill)b, bRange));
-                case ShapeContentType.Transform:
-                    return MergeResult<ShapeLayerContent>.From(MergeTransform((Transform)a, aRange, (Transform)b, bRange));
                 case ShapeContentType.SolidColorFill:
                     return MergeResult<ShapeLayerContent>.From(MergeSolidColorFills((SolidColorFill)a, aRange, (SolidColorFill)b, bRange));
                 case ShapeContentType.SolidColorStroke:
                     return MergeResult<ShapeLayerContent>.From(MergeSolidColorStrokes((SolidColorStroke)a, aRange, (SolidColorStroke)b, bRange));
+                case ShapeContentType.Transform:
+                    return MergeResult<ShapeLayerContent>.From(MergeTransform((Transform)a, aRange, (Transform)b, bRange));
+                case ShapeContentType.TrimPath:
+                    return MergeResult<ShapeLayerContent>.From(MergeTrimPaths((TrimPath)a, aRange, (TrimPath)b, bRange));
             }
 
             return MergeResult<ShapeLayerContent>.Failed;

--- a/source/LottieReader/Serialization/LottieCompositionReader.cs
+++ b/source/LottieReader/Serialization/LottieCompositionReader.cs
@@ -288,8 +288,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieData.Serialization
                                                     layers: new LayerCollection(layers),
                                                     markers: markers);
 
-                                result = LottieMergeOptimizer.Optimize(result);
-
                                 return result;
                             }
 


### PR DESCRIPTION
- I added more merge helper methods (They are used in some animations). 
- Removed some checks since it seems that they are no longer needed. Now we can optimize more cases.
  - We should be able to merge nested LayerPreComp (Previously I noticed a bug with that so I added this check but I can no longer reproduce it). 
  - I don't know why I added `aAsset == bAsset` check since I'm making a copy of it anyway a line below (`WithTimeOffset` creates a copy).

- Turned out that previously I was calling optimizer in wrong place. It was too deep so LottieGen called it twice and even with command line option -DisableLottieMergeOptimizer. So I moved it higher in the stack.