### PR TITLE
UI Markers improvement

### DIFF
--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -261,8 +261,9 @@
                                     <DataTemplate x:Key="MarkerWithDurationTemplate" x:DataType="viewmodel:MarkerWithDuration">
                                         <StackPanel Orientation="Horizontal" Margin="0,0,0,2" MaxWidth="310">
                                             <TextBlock Foreground="White" TextAlignment="Right" TextWrapping="Wrap" MaxWidth="250" MinWidth="60" Padding="0,0,12,0">
-                                                <Hyperlink Foreground="{StaticResource LottieHyperlinkForegroundBrush}" Click="MarkerClick"><Run Text="{x:Bind InFrame}"/></Hyperlink> -
-                                                <Hyperlink Foreground="{StaticResource LottieHyperlinkForegroundBrush}" Click="MarkerEndClick"><Run Text="{x:Bind OutFrame}"/></Hyperlink>
+                                                <Hyperlink Foreground="{StaticResource LottieHyperlinkForegroundBrush}" Click="MarkerWithDurationClick">
+                                                    <Run Text="{x:Bind InFrame}"/>-<Run Text="{x:Bind OutFrame}"/>
+                                                </Hyperlink>
                                             </TextBlock>
                                             <TextBlock Foreground="White" TextWrapping="Wrap" Text="{x:Bind Name}"/>
                                         </StackPanel>

--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -433,11 +433,11 @@ namespace LottieViewer
         }
 
         // Called when the user clicks on a marker-with-duration hyperlink.
-        void MarkerEndClick(Hyperlink sender, HyperlinkClickEventArgs args)
+        void MarkerWithDurationClick(Hyperlink sender, HyperlinkClickEventArgs args)
         {
             var dataContext = ((FrameworkElement)sender.ElementStart.Parent).DataContext;
             var marker = (MarkerWithDuration)dataContext;
-            SeekToProgressValue(marker.ConstrainedOutProgress);
+            _ = _stage.Player?.PlayAsync(marker.ConstrainedInProgress, marker.ConstrainedOutProgress, looped: true);
         }
 
         // Sets the progress to the given value, and sets the focus to the scrubber

--- a/LottieViewer/PropertiesTemplateSelector.cs
+++ b/LottieViewer/PropertiesTemplateSelector.cs
@@ -24,13 +24,13 @@ namespace LottieViewer
             {
                 return Normal;
             }
-            else if (item is Marker)
+            else if (item is MarkerWithDuration)
             {
-                return Marker;
+                return MarkerWithDuration;
             }
             else
             {
-                return MarkerWithDuration;
+                return Marker;
             }
         }
     }


### PR DESCRIPTION
Now two markers with `_Start` and `_End` suffixes and same prefix will be combined together into one MarkerWithDuration. It is not affecting LottieGen or Lottie at all, only LottieViewer. Now after you click on MarkerWithDuration hyperlink it will play the corresponding animation segment in loop.

![image](https://user-images.githubusercontent.com/83784664/130304815-04329d2d-969d-4570-93c9-77284ae348a3.png)
