### PR TITLE
[LottieViewer] Pixel View feature added

### DIFF
--- a/LottieViewer/LottieViewer.csproj
+++ b/LottieViewer/LottieViewer.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AnimatedVisuals\UiFeedbackAnimations.cs" />
     <Compile Include="AnimatedVisuals\LottieLogo.cs" />
     <Compile Include="ColorPaletteEntry.cs" />
+    <Compile Include="PixelViewElement.cs" />
     <Compile Include="FeedbackLottie.xaml.cs">
       <DependentUpon>FeedbackLottie.xaml</DependentUpon>
     </Compile>

--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -203,6 +203,7 @@
                                     StepFrequency="1"
                                     TickFrequency="16"
                                     TickPlacement="TopLeft"
+                                    ValueChanged="CanvasSizeSliderChanged"
                                     Value="{x:Bind _stage.PlayerContainer.MaxHeight, Mode=TwoWay}">
                                     <Slider.Resources>
                                         <!-- 

--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -88,7 +88,7 @@
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <Grid.Resources>
-                <x:Double x:Key="ControlPanelWidth">355</x:Double>
+                <x:Double x:Key="ControlPanelWidth">400</x:Double>
             </Grid.Resources>
             <!--  The stage. This is where the Lotties are displayed.  -->
             <local:Stage x:Name="_stage" ArtboardColor="{x:Bind ArtboardBrush.Color, Mode=OneWay}" />
@@ -185,6 +185,7 @@
                             </Grid>
                         </StackPanel>
                         
+                        <!-- Canvas size slider. -->
                         <StackPanel>
                             <TextBlock FontWeight="Bold" >Canvas size</TextBlock>
                             <Grid Margin="20,14,20,20">
@@ -217,6 +218,21 @@
                                 </Slider>
                                 <TextBlock Grid.Column="1" Margin="10,0,0,0"><Run Text="{x:Bind _stage.PlayerContainer.MaxHeight, Mode=OneWay, Converter={StaticResource floatFormatter}}"/>px</TextBlock>
                             </Grid>
+                        </StackPanel>
+
+                        <!-- Separator -->
+                        <Border Style="{StaticResource SeparatorStyle}"/>
+                        <TextBlock FontWeight="Bold" Margin="0,0,0,10">Pixel view</TextBlock>
+
+                        <!-- Pixel View. -->
+                        <local:PixelViewElement x:Name="_pixelView">
+                            <Rectangle PointerMoved="{x:Bind _pixelView.OnMouseMove}" Height="auto" Width="auto" Fill="White"></Rectangle>
+                        </local:PixelViewElement>
+
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="10,0,0,0">
+                            <TextBlock Margin="5,0">Position: <Run Text="{x:Bind _pixelView.CurrentPosition, Mode=OneWay}"/></TextBlock>
+                            <TextBlock>Color: <Run Text="{x:Bind _pixelView.CurrentColorString, Mode=OneWay}"/></TextBlock>
+                            <Rectangle Width="10" Height="10" Margin="5" Fill="{x:Bind _pixelView.CurrentColorString, Mode=OneWay}"></Rectangle>
                         </StackPanel>
 
                         <!-- Separator -->

--- a/LottieViewer/MainPage.xaml
+++ b/LottieViewer/MainPage.xaml
@@ -203,7 +203,6 @@
                                     StepFrequency="1"
                                     TickFrequency="16"
                                     TickPlacement="TopLeft"
-                                    ValueChanged="CanvasSizeSliderChanged"
                                     Value="{x:Bind _stage.PlayerContainer.MaxHeight, Mode=TwoWay}">
                                     <Slider.Resources>
                                         <!-- 

--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -195,7 +195,7 @@ namespace LottieViewer
                     _playStopButton.IsChecked = true;
 
                     // Loading succeeded, update pixel view resolution.
-                    _pixelView.UpdateResolution((int)_stage.PlayerContainer.ActualWidth, (int)_stage.PlayerContainer.ActualHeight);
+                    _pixelView.OnResolutionUpdated((int)_stage.PlayerContainer.ActualWidth, (int)_stage.PlayerContainer.ActualHeight);
                 }
             }
             finally
@@ -292,7 +292,7 @@ namespace LottieViewer
                 _playStopButton.IsChecked = true;
 
                 // Loading succeeded, update pixel view resolution.
-                _pixelView.UpdateResolution((int)_stage.PlayerContainer.ActualWidth, (int)_stage.PlayerContainer.ActualHeight);
+                _pixelView.OnResolutionUpdated((int)_stage.PlayerContainer.ActualWidth, (int)_stage.PlayerContainer.ActualHeight);
             }
         }
 
@@ -319,14 +319,6 @@ namespace LottieViewer
             {
                 UncheckPlayStopButton();
                 _stage.Player.SetProgress(e.NewValue);
-            }
-        }
-
-        void CanvasSizeSliderChanged(object sender, RangeBaseValueChangedEventArgs e)
-        {
-            if (_pixelView != null && _stage.PlayerContainer.ActualHeight > 0)
-            {
-                _pixelView.UpdateResolution((int)(_stage.PlayerContainer.ActualWidth / _stage.PlayerContainer.ActualWidth * e.NewValue), (int)e.NewValue);
             }
         }
 

--- a/LottieViewer/MainPage.xaml.cs
+++ b/LottieViewer/MainPage.xaml.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using LottieViewer.ViewModel;
 using Windows.ApplicationModel;
@@ -18,6 +19,7 @@ using Windows.Foundation.Metadata;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -34,6 +36,8 @@ namespace LottieViewer
     public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
         readonly ToggleButton[] _controlPanelButtons;
+        readonly Timer timer;
+
         int _playControlToggleVersion;
         int _playVersion;
 
@@ -60,6 +64,16 @@ namespace LottieViewer
 
             // Remove all of the control panel panes. They will be added back as needed.
             ControlPanel.Children.Clear();
+
+            timer = new Timer(TimerCallback, null, 0, (int)TimeSpan.FromMilliseconds(200).TotalMilliseconds);
+        }
+
+        private void TimerCallback(object state)
+        {
+            _ = Dispatcher.RunAsync(CoreDispatcherPriority.High, () =>
+            {
+                _ = _pixelView.UpdatePixelViewAsync(_stage.PlayerContainer);
+            });
         }
 
         public ObservableCollection<object> PropertiesList { get; } = new ObservableCollection<object>();
@@ -303,6 +317,8 @@ namespace LottieViewer
 
         void ProgressSliderChanged(object sender, ScrubberValueChangedEventArgs e)
         {
+            _ = _pixelView.UpdatePixelViewAsync(_stage.PlayerContainer);
+
             if (!_ignoreScrubberValueChanges)
             {
                 UncheckPlayStopButton();

--- a/LottieViewer/PixelViewElement.cs
+++ b/LottieViewer/PixelViewElement.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.Effects;
+using Microsoft.Graphics.Canvas.UI.Composition;
+using Windows.Foundation;
+using Windows.Graphics;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using Windows.UI;
+using Windows.UI.Composition;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Input;
+
+#nullable enable
+
+namespace LottieViewer
+{
+    public sealed class PixelViewElement : UserControl
+    {
+        readonly SpriteVisual _visual;
+        bool _comparisonIsUnderway = false;
+        bool _comparisonIsQueued = false;
+
+        // Checkerboard pattern bitmap.
+        static CanvasBitmap? _patternBitmap = null;
+
+        // Previously rendered bitmap info.
+        CanvasBitmap? _previousBitmap = null;
+        Color[]? _previousColors = null;
+        int _previousScale = 1;
+
+        Color? _currentColor = null;
+
+        public static readonly DependencyProperty CurrentColorStringProperty =
+        DependencyProperty.RegisterAttached(
+          "CurrentColorString",
+          typeof(string),
+          typeof(PixelViewElement),
+          new PropertyMetadata("#FFFFFFFF")
+        );
+
+        public static readonly DependencyProperty CurrentPositionProperty =
+        DependencyProperty.RegisterAttached(
+          "CurrentColorString",
+          typeof(Vector2),
+          typeof(PixelViewElement),
+          new PropertyMetadata(new Vector2(0, 0))
+        );
+
+        public string CurrentColorString
+        {
+            get { return (string)GetValue(CurrentColorStringProperty); }
+            set { SetValue(CurrentColorStringProperty, value); }
+        }
+
+        public Vector2 CurrentPosition
+        {
+            get { return (Vector2)GetValue(CurrentPositionProperty); }
+            set { SetValue(CurrentPositionProperty, value); }
+        }
+
+        public PixelViewElement()
+        {
+            var c = ElementCompositionPreview.GetElementVisual(this).Compositor;
+            _visual = c.CreateSpriteVisual();
+            _visual.RelativeSizeAdjustment = Vector2.One;
+            ElementCompositionPreview.SetElementChildVisual(this, _visual);
+        }
+
+        public void OnMouseMove(object sender, PointerRoutedEventArgs e)
+        {
+            var position = e.GetCurrentPoint(this).Position;
+            if (_previousScale < 0 || _previousBitmap == null || ActualHeight <= 0)
+            {
+                return;
+            }
+
+            int pixelX = (int)Math.Floor(position.X * (_previousBitmap.Size.Height / ActualHeight));
+            int pixelY = (int)Math.Floor(position.Y * (_previousBitmap.Size.Width / ActualWidth));
+            if (pixelX < 0 || pixelX >= _previousBitmap.SizeInPixels.Width || pixelY < 0 || pixelY >= _previousBitmap.SizeInPixels.Height)
+            {
+                return;
+            }
+
+            if (_previousColors == null)
+            {
+                _previousColors = _previousBitmap.GetPixelColors();
+            }
+
+            _currentColor = _previousColors[(pixelY * _previousBitmap.SizeInPixels.Width) + pixelX];
+            SetValue(CurrentColorStringProperty, _currentColor.ToString());
+            SetValue(CurrentPositionProperty, new Vector2(pixelX, pixelY));
+        }
+
+        public async Task UpdatePixelViewAsync(FrameworkElement element)
+        {
+            _comparisonIsQueued = true;
+
+            if (!_comparisonIsUnderway)
+            {
+                _comparisonIsUnderway = true;
+                while (_comparisonIsQueued)
+                {
+                    _comparisonIsQueued = false;
+                    try
+                    {
+                        var bitmap = await RenderElementToBitmapAsync(element);
+                        await ShowBitmapOnTargetAsync(bitmap);
+                    }
+                    catch { }
+                }
+
+                _comparisonIsUnderway = false;
+            }
+        }
+
+        async Task ShowBitmapOnTargetAsync(CanvasBitmap bitmap)
+        {
+            int scale = (int)Math.Ceiling(ActualSize.Y / bitmap.Size.Height);
+
+            Height = bitmap.Size.Height / bitmap.Size.Width * ActualSize.X;
+
+            _previousBitmap = bitmap;
+            _previousScale = scale;
+            _previousColors = null;
+
+            var compositor = ElementCompositionPreview.GetElementVisual(this).Compositor;
+            var compositionGraphicsDevice = CanvasComposition.CreateCompositionGraphicsDevice(compositor, CanvasDevice.GetSharedDevice());
+
+            if (_patternBitmap is null)
+            {
+                _patternBitmap = await CanvasBitmap.LoadAsync(CanvasDevice.GetSharedDevice(), @"Assets\BackgroundPattern.png");
+            }
+
+            var surface = compositionGraphicsDevice.CreateDrawingSurface(
+                new Size(bitmap.Size.Width * scale, bitmap.Size.Height * scale),
+                DirectXPixelFormat.B8G8R8A8UIntNormalized,
+                DirectXAlphaMode.Premultiplied);
+
+            using (var drawingSession = CanvasComposition.CreateDrawingSession(surface))
+            {
+                var border = new BorderEffect
+                {
+                    ExtendX = CanvasEdgeBehavior.Wrap,
+                    ExtendY = CanvasEdgeBehavior.Wrap,
+                    Source = _patternBitmap,
+                };
+
+                var scaleEffect = new ScaleEffect
+                {
+                    Scale = new Vector2(scale, scale),
+                    InterpolationMode = CanvasImageInterpolation.NearestNeighbor,
+                };
+
+                scaleEffect.Source = border;
+                drawingSession.DrawImage(scaleEffect);
+                scaleEffect.Source = bitmap;
+                drawingSession.DrawImage(scaleEffect);
+            }
+
+            var surfaceBrush = compositor.CreateSurfaceBrush(surface);
+            _visual.Brush = surfaceBrush;
+        }
+
+        /// <summary>
+        /// Renders a bitmap of the given <see cref="FrameworkElement"/>.
+        /// </summary>
+        static Task<CanvasBitmap> RenderElementToBitmapAsync(FrameworkElement element)
+            => RenderVisualToBitmapAsync(
+                ElementCompositionPreview.GetElementVisual(element),
+                new SizeInt32 { Width = (int)element.ActualWidth, Height = (int)element.ActualHeight });
+
+        /// <summary>
+        /// Renders a the given <see cref="Visual"/> to a <see cref="CanvasBitmap"/>. If <paramref name="size"/> is not
+        /// specified, uses the size of <paramref name="visual"/>.
+        /// </summary>
+        static async Task<CanvasBitmap> RenderVisualToBitmapAsync(Visual visual, SizeInt32? size = null)
+        {
+            visual.BorderMode = CompositionBorderMode.Soft;
+
+            // Get an object that enables capture from a visual.
+            var graphicsItem = GraphicsCaptureItem.CreateFromVisual(visual);
+
+            var canvasDevice = CanvasDevice.GetSharedDevice();
+
+            var tcs = new TaskCompletionSource<CanvasBitmap>();
+
+            // Create a frame pool with room for only 1 frame because we're getting a single frame, not a video.
+            const int numberOfBuffers = 1;
+            using (var framePool = Direct3D11CaptureFramePool.Create(
+                                canvasDevice,
+                                DirectXPixelFormat.B8G8R8A8UIntNormalized,
+                                numberOfBuffers,
+                                size ?? graphicsItem.Size))
+            {
+                void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
+                {
+                    using (var frame = sender.TryGetNextFrame())
+                    {
+                        tcs.SetResult(CanvasBitmap.CreateFromDirect3D11Surface(canvasDevice, frame.Surface));
+                    }
+                }
+
+                using (var session = framePool.CreateCaptureSession(graphicsItem))
+                {
+                    framePool.FrameArrived += OnFrameArrived;
+
+                    // Start capturing. The FrameArrived event will occur shortly.
+                    session.StartCapture();
+
+                    // Wait for the frame to arrive.
+                    var result = await tcs.Task;
+
+                    // !!!!!!!! NOTE !!!!!!!!
+                    // This thread is now running inside the OnFrameArrived callback method.
+
+                    // Unsubscribe now that we have captured the frame.
+                    framePool.FrameArrived -= OnFrameArrived;
+
+                    // Yield to allow the OnFrameArrived callback to unwind so that it is safe to
+                    // Dispose the session and framepool.
+                    await Task.Yield();
+                }
+            }
+
+            return await tcs.Task;
+        }
+    }
+}

--- a/LottieViewer/PixelViewElement.cs
+++ b/LottieViewer/PixelViewElement.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
 using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Graphics.Canvas;
@@ -14,8 +20,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
-
-#nullable enable
 
 namespace LottieViewer
 {

--- a/LottieViewer/PixelViewElement.cs
+++ b/LottieViewer/PixelViewElement.cs
@@ -38,6 +38,10 @@ namespace LottieViewer
 
         Color? _currentColor = null;
 
+        Direct3D11CaptureFramePool? _framePool = null;
+        GraphicsCaptureSession? _session = null;
+        CanvasDevice? _canvasDevice = null;
+
         public static readonly DependencyProperty CurrentColorStringProperty =
         DependencyProperty.RegisterAttached(
           "CurrentColorString",
@@ -78,10 +82,13 @@ namespace LottieViewer
 
         public void SetElementToCapture(FrameworkElement element)
         {
+            element.SizeChanged += (object sender, SizeChangedEventArgs e) =>
+                  OnResolutionUpdated((int)element.ActualWidth, (int)element.ActualHeight);
+
             _capturedVisual = ElementCompositionPreview.GetElementVisual(element);
             _capturedVisual.BorderMode = CompositionBorderMode.Soft;
 
-            UpdateResolution((int)element.ActualWidth, (int)element.ActualHeight);
+            OnResolutionUpdated((int)element.ActualWidth, (int)element.ActualHeight);
         }
 
         public void OnMouseMove(object sender, PointerRoutedEventArgs e)
@@ -158,10 +165,6 @@ namespace LottieViewer
             _spriteVisual.Brush = surfaceBrush;
         }
 
-        Direct3D11CaptureFramePool? _framePool = null;
-        GraphicsCaptureSession? _session = null;
-        CanvasDevice? _canvasDevice = null;
-
         void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
         {
             using (var frame = sender.TryGetNextFrame())
@@ -171,12 +174,12 @@ namespace LottieViewer
             }
         }
 
-        public void UpdateResolution(int width, int height)
+        public void OnResolutionUpdated(int width, int height)
             => UpdateResolution(new SizeInt32 { Width = width, Height = height });
 
         public void UpdateResolution(SizeInt32 size)
         {
-            if (size.Height == 0 || size.Width == 0)
+            if (size.Height <= 0 || size.Width <= 0)
             {
                 return;
             }


### PR DESCRIPTION
Adding **PixelView** feature. This feature should allow designers to examine animations precisely pixel-by-pixel, so that they can ensure that animation will be displayed correctly at any resolution.

![PixelView](https://user-images.githubusercontent.com/83784664/130698793-145662af-74cc-4f8c-b6e9-30d4be4535db.gif)
