### PR TITLE
[LottieGen] Added IAnimatedVisual2 implementation preview.

### DIFF
--- a/source/LottieToWinComp/Transforms.cs
+++ b/source/LottieToWinComp/Transforms.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Toolkit.Uwp.UI.Lottie.Animatables;
 using Microsoft.Toolkit.Uwp.UI.Lottie.LottieData;
@@ -228,7 +229,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     visibilityAnimation.InsertKeyFrame(0.0f, Sn.Vector2.Zero, context.ObjectFactory.CreateHoldThenStepEasingFunction());
                 }
 
-                visibilityAnimation.InsertKeyFrame(inProgress, Sn.Vector2.One, context.ObjectFactory.CreateHoldThenStepEasingFunction());
+                visibilityAnimation.InsertKeyFrame(Math.Max(0.0f, inProgress), Sn.Vector2.One, context.ObjectFactory.CreateHoldThenStepEasingFunction());
 
                 if (outProgress < 1)
                 {
@@ -341,7 +342,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                     visibilityAnimation.InsertKeyFrame(0.0f, false);
                 }
 
-                visibilityAnimation.InsertKeyFrame(inProgress, true);
+                visibilityAnimation.InsertKeyFrame(Math.Max(0.0f, inProgress), true);
 
                 if (outProgress < 1)
                 {

--- a/source/LottieToWinComp/Transforms.cs
+++ b/source/LottieToWinComp/Transforms.cs
@@ -225,8 +225,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 {
                     // Set initial value to be non-visible (default is visible).
                     visibilityNode.Scale = Sn.Vector2.Zero;
-                    visibilityAnimation.InsertKeyFrame(inProgress, Sn.Vector2.One, context.ObjectFactory.CreateHoldThenStepEasingFunction());
+                    visibilityAnimation.InsertKeyFrame(0.0f, Sn.Vector2.Zero, context.ObjectFactory.CreateHoldThenStepEasingFunction());
                 }
+
+                visibilityAnimation.InsertKeyFrame(inProgress, Sn.Vector2.One, context.ObjectFactory.CreateHoldThenStepEasingFunction());
 
                 if (outProgress < 1)
                 {
@@ -336,8 +338,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 {
                     // Set initial value to be non-visible.
                     visibilityNode.IsVisible = false;
-                    visibilityAnimation.InsertKeyFrame(inProgress, true);
+                    visibilityAnimation.InsertKeyFrame(0.0f, false);
                 }
+
+                visibilityAnimation.InsertKeyFrame(inProgress, true);
 
                 if (outProgress < 1)
                 {
@@ -345,7 +349,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
 
                 visibilityAnimation.Duration = context.LottieComposition.Duration;
-                Animate.WithKeyFrame(context, visibilityNode, "IsVisible", visibilityAnimation);
+                Animate.WithKeyFrame(context, visibilityNode, nameof(visibilityNode.IsVisible), visibilityAnimation);
             }
         }
 

--- a/source/UIData/Tools/GraphCompactor.cs
+++ b/source/UIData/Tools/GraphCompactor.cs
@@ -826,15 +826,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.Tools
 
                 foreach (var (isVisible, progress) in compositeVisibility.Sequence)
                 {
-                    if (progress == 0)
-                    {
-                        // The 0 progress value is already handled.
-                        continue;
-                    }
-                    else
-                    {
-                        animation.InsertKeyFrame(progress, isVisible);
-                    }
+                    animation.InsertKeyFrame(progress, isVisible);
                 }
 
                 to.StartAnimation("IsVisible", animation);

--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
         protected override void WriteAnimatedVisualStart(CodeBuilder builder, IAnimatedVisualInfo info)
         {
             // Start the instantiator class.
-            if (_implementIAnimatedVisual2)
+            if (info.ImplementCreateAndDestroyMethods)
             {
                 builder.WriteLine($"sealed class {info.ClassName} : {Interface_IAnimatedVisual2.GetQualifiedName(_s)}");
             }
@@ -758,7 +758,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
         // Called by the base class to write the end of the AnimatedVisual class.
         protected override void WriteAnimatedVisualEnd(
             CodeBuilder builder,
-            IAnimatedVisualInfo info)
+            IAnimatedVisualInfo info,
+            CodeBuilder createAnimations,
+            CodeBuilder destroyAnimations)
         {
             // Write the constructor for the AnimatedVisual class.
             builder.WriteLine($"internal {info.ClassName}(");
@@ -794,6 +796,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
             builder.WriteLine($"public Vector2 Size => {_s.Vector2(SourceInfo.CompositionDeclaredSize)};");
             builder.WriteLine("void IDisposable.Dispose() => _root?.Dispose();");
             builder.WriteLine();
+
+            if (info.ImplementCreateAndDestroyMethods)
+            {
+                builder.WriteLine($"public void {CreateAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(createAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
+
+                builder.WriteLine($"public void {DestroyAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(destroyAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
+            }
 
             // WinUI3 doesn't ever do a version check. It's up to the user to make sure
             // the version they're using is compatible.
@@ -1058,7 +1075,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
             builder.WriteLine(");");
             builder.UnIndent();
 
-            if (_implementIAnimatedVisual2)
+            if (info.ImplementCreateAndDestroyMethods)
             {
                 builder.WriteLine($"res.{CreateAnimationsMethod}();");
             }

--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -727,7 +727,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
         protected override void WriteAnimatedVisualStart(CodeBuilder builder, IAnimatedVisualInfo info)
         {
             // Start the instantiator class.
-            builder.WriteLine($"sealed class {info.ClassName} : {Interface_IAnimatedVisual.GetQualifiedName(_s)}");
+            if (_implementIAnimatedVisual2)
+            {
+                builder.WriteLine($"sealed class {info.ClassName} : {Interface_IAnimatedVisual2.GetQualifiedName(_s)}");
+            }
+            else
+            {
+                builder.WriteLine($"sealed class {info.ClassName} : {Interface_IAnimatedVisual.GetQualifiedName(_s)}");
+            }
+
             builder.OpenScope();
         }
 
@@ -1042,13 +1050,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
 
         void WriteInstantiateAndReturnAnimatedVisual(CodeBuilder builder, IAnimatedVisualInfo info)
         {
-            builder.WriteLine("return");
+            builder.WriteLine("var res = ");
             builder.Indent();
             builder.WriteLine($"new {info.ClassName}(");
             builder.Indent();
             builder.WriteCommaSeparatedLines(GetConstructorArguments(info));
             builder.WriteLine(");");
             builder.UnIndent();
+
+            if (_implementIAnimatedVisual2)
+            {
+                builder.WriteLine($"res.{InstantiateAnimationsMethod}(0.0f);");
+            }
+
+            builder.WriteLine("return res;");
             builder.UnIndent();
         }
     }

--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -1060,7 +1060,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.CSharp
 
             if (_implementIAnimatedVisual2)
             {
-                builder.WriteLine($"res.{InstantiateAnimationsMethod}(0.0f);");
+                builder.WriteLine($"res.{CreateAnimationsMethod}();");
             }
 
             builder.WriteLine("return res;");

--- a/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
+++ b/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
@@ -113,5 +113,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         /// The version of WinUI to target.
         /// </summary>
         public Version WinUIVersion { get; set; }
+
+        public bool ImplementCreateAndDestroyMethods => WinUIVersion >= Version.Parse("2.7");
     }
 }

--- a/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
             builder.Indent();
             builder.Indent();
 
-            if (_implementIAnimatedVisual2)
+            if (info.ImplementCreateAndDestroyMethods)
             {
                 builder.WriteLine($"winrt::{_animatedVisualTypeName2},");
             }
@@ -1082,7 +1082,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
             {
                 var info = animatedVisualInfos.First();
                 builder.WriteBreakableLine($"auto result = winrt::make<{info.ClassName}>(", CommaSeparate(GetConstructorArguments(info)), ");");
-                if (_implementIAnimatedVisual2)
+                if (info.ImplementCreateAndDestroyMethods)
                 {
                     builder.WriteLine($"result.{CreateAnimationsMethod}();");
                 }
@@ -1096,7 +1096,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
                     builder.WriteLine($"if ({info.ClassName}::IsRuntimeCompatible())");
                     builder.OpenScope();
                     builder.WriteBreakableLine($"auto result = winrt::make<{info.ClassName}>(", CommaSeparate(GetConstructorArguments(info)), ");");
-                    if (_implementIAnimatedVisual2)
+                    if (info.ImplementCreateAndDestroyMethods)
                     {
                         builder.WriteLine($"result.{CreateAnimationsMethod}();");
                     }
@@ -1288,7 +1288,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
         // Called by the base class to write the end of the AnimatedVisual class.
         protected override void WriteAnimatedVisualEnd(
             CodeBuilder builder,
-            IAnimatedVisualInfo info)
+            IAnimatedVisualInfo info,
+            CodeBuilder createAnimations,
+            CodeBuilder destroyAnimations)
         {
             if (SourceInfo.UsesCanvasEffects ||
                 SourceInfo.UsesCanvasGeometry)
@@ -1366,6 +1368,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
                 var propertyImplBuilder = new CodeBuilder();
                 propertyImplBuilder.WriteLine($"return {_s.Vector2(SourceInfo.CompositionDeclaredSize)};");
                 WritePropertyImpl(builder, "float2", "Size", propertyImplBuilder);
+            }
+
+            if (info.ImplementCreateAndDestroyMethods)
+            {
+                builder.WriteLine($"void {CreateAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(createAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
+
+                builder.WriteLine($"void {DestroyAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(destroyAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
             }
 
             WriteIsRuntimeCompatibleMethod(builder, info);

--- a/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
@@ -1084,7 +1084,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
                 builder.WriteBreakableLine($"auto result = winrt::make<{info.ClassName}>(", CommaSeparate(GetConstructorArguments(info)), ");");
                 if (_implementIAnimatedVisual2)
                 {
-                    builder.WriteLine($"result.{InstantiateAnimationsMethod}(0.0f);");
+                    builder.WriteLine($"result.{CreateAnimationsMethod}();");
                 }
 
                 builder.WriteLine("return result;");
@@ -1098,7 +1098,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cppwinrt
                     builder.WriteBreakableLine($"auto result = winrt::make<{info.ClassName}>(", CommaSeparate(GetConstructorArguments(info)), ");");
                     if (_implementIAnimatedVisual2)
                     {
-                        builder.WriteLine($"result.{InstantiateAnimationsMethod}(0.0f);");
+                        builder.WriteLine($"result.{CreateAnimationsMethod}();");
                     }
 
                     builder.WriteLine("return result;");

--- a/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
@@ -1009,7 +1009,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                 builder.WriteBreakableLine($"auto result = {_s.New(info.ClassName)}(", CommaSeparate(GetConstructorArguments(info)), ");");
                 if (_implementIAnimatedVisual2)
                 {
-                    builder.WriteLine($"result.{InstantiateAnimationsMethod}(0.0f);");
+                    builder.WriteLine($"result.{CreateAnimationsMethod}();");
                 }
 
                 builder.WriteLine("return result;");
@@ -1024,7 +1024,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                     builder.WriteBreakableLine($"auto result = {_s.New(info.ClassName)}(", CommaSeparate(GetConstructorArguments(info)), ");");
                     if (_implementIAnimatedVisual2)
                     {
-                        builder.WriteLine($"result.{InstantiateAnimationsMethod}(0.0f);");
+                        builder.WriteLine($"result.{CreateAnimationsMethod}();");
                     }
 
                     builder.WriteLine("return result;");

--- a/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
             builder.WriteLine($"ref class {info.ClassName} sealed");
             builder.Indent();
 
-            if (_implementIAnimatedVisual2)
+            if (info.ImplementCreateAndDestroyMethods)
             {
                 builder.WriteLine($": public {_animatedVisualTypeName2}");
             }
@@ -1007,7 +1007,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
             {
                 var info = animatedVisualInfos.First();
                 builder.WriteBreakableLine($"auto result = {_s.New(info.ClassName)}(", CommaSeparate(GetConstructorArguments(info)), ");");
-                if (_implementIAnimatedVisual2)
+                if (info.ImplementCreateAndDestroyMethods)
                 {
                     builder.WriteLine($"result.{CreateAnimationsMethod}();");
                 }
@@ -1022,7 +1022,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                     builder.WriteLine($"if ({info.ClassName}::IsRuntimeCompatible())");
                     builder.OpenScope();
                     builder.WriteBreakableLine($"auto result = {_s.New(info.ClassName)}(", CommaSeparate(GetConstructorArguments(info)), ");");
-                    if (_implementIAnimatedVisual2)
+                    if (info.ImplementCreateAndDestroyMethods)
                     {
                         builder.WriteLine($"result.{CreateAnimationsMethod}();");
                     }
@@ -1181,7 +1181,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
         // Called by the base class to write the end of the AnimatedVisual class.
         protected override void WriteAnimatedVisualEnd(
             CodeBuilder builder,
-            IAnimatedVisualInfo info)
+            IAnimatedVisualInfo info,
+            CodeBuilder createAnimations,
+            CodeBuilder destroyAnimations)
         {
             if (SourceInfo.UsesCanvasEffects ||
                 SourceInfo.UsesCanvasGeometry)
@@ -1268,6 +1270,21 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen.Cx
                 var propertyImplBuilder = new CodeBuilder();
                 propertyImplBuilder.WriteLine($"return {_s.Vector2(SourceInfo.CompositionDeclaredSize)};");
                 WritePropertyImpl(builder, isVirtual: true, "float2", "Size", propertyImplBuilder);
+            }
+
+            if (info.ImplementCreateAndDestroyMethods)
+            {
+                builder.WriteLine($"public void {CreateAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(createAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
+
+                builder.WriteLine($"public void {DestroyAnimationsMethod}()");
+                builder.OpenScope();
+                builder.WriteCodeBuilder(destroyAnimations);
+                builder.CloseScope();
+                builder.WriteLine();
             }
 
             WriteIsRuntimeCompatibleMethod(builder, info);

--- a/source/UIDataCodeGen/CodeGen/IAnimatedVisualInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/IAnimatedVisualInfo.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.UIData.CodeGen
         uint RequiredUapVersion { get; }
 
         /// <summary>
+        /// Do we need to implement CreateAnimations and DestroyAnimations method.
+        /// Available after WinUI 2.7 with new interface IAnimatedVisual2.
+        /// </summary>
+        bool ImplementCreateAndDestroyMethods { get; }
+
+        /// <summary>
         /// Gets the XAML LoadedImageSurface nodes of the AnimatedVisual.
         /// </summary>
         IReadOnlyList<LoadedImageSurfaceInfo> LoadedImageSurfaceNodes { get; }


### PR DESCRIPTION
Added implementation of IAnimatedVisual2 interface that is going to be added to xaml controls: https://github.com/microsoft/microsoft-ui-xaml/pull/6268. It is disabled by a boolean flag for now, later we will decide if we want to enable it by default (with version check) or to add a command line argument.

```
interface IAnimatedVisual2 {
    void InstantiateAnimations(); 
    void DestroyAnimations();
}
```

We also have to ensure that all the animations have zero keyframes (progress = 0.0) in order to correctly re-instantiate animation states, previously we were discarding some zero keyframes.