### PR TITLE
[LottieGen] Fixed UAP version check for Drop Shadow effect

### DIFF
--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -109,6 +109,12 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             Visual source,
             DropShadowEffect dropShadowEffect)
         {
+            if (!context.ObjectFactory.IsUapApiAvailable(nameof(CompositionVisualSurface), versionDependentFeatureDescription: "Drop Shadow"))
+            {
+                // The effect can't be displayed on the targeted version.
+                return source;
+            }
+
             Debug.Assert(dropShadowEffect.IsEnabled, "Precondition");
             Debug.Assert(context is PreCompLayerContext || context is ShapeLayerContext, "Precondition");
 


### PR DESCRIPTION
We need this version check for DropShadow effect since it can't be supported for UAP <=7 , so just fall back to no shadow in this case.