### PR TITLE
[LottieGen] Fixed layer combining for Exclude mode

### DIFF
--- a/source/LottieToWinComp/Shapes.cs
+++ b/source/LottieToWinComp/Shapes.cs
@@ -313,9 +313,20 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return CanvasGeometryCombiner.CombineGeometries(geometries, combineMode);
 #else
                 var accumulator = geometries[0];
-                for (var i = 1; i < geometries.Length; i++)
+                if (combineMode == CanvasGeometryCombine.Exclude)
                 {
-                    accumulator = accumulator.CombineWith(geometries[i], Sn.Matrix3x2.Identity, combineMode);
+                    // TODO: investiagte how it works for 3+ layers with Exclude mode
+                    for (var i = 1; i < geometries.Length; i++)
+                    {
+                        accumulator = geometries[i].CombineWith(accumulator, Sn.Matrix3x2.Identity, combineMode);
+                    }
+                }
+                else
+                {
+                    for (var i = 1; i < geometries.Length; i++)
+                    {
+                        accumulator = accumulator.CombineWith(geometries[i], Sn.Matrix3x2.Identity, combineMode);
+                    }
                 }
 
                 return accumulator;


### PR DESCRIPTION
It seems that AfterEffects is applying layer combination mode in reverse order. It does not affect Intersect/Union/Xor but it affects how Exclude mode works, so we need to reverse the order. `Exclude[layer1, layer2]` should be interpreted as `(layer2 - layer1)`

Note: We should do more investigation how it works  for more than 3 layers, but currently I do not have an example of animation that uses 3 layers or more with Exclude mode, but even then it should be pretty rare case. `Exclude[layer1, layer2, layer3]` may be interpreted as `(layer3 - (layer2 - layer1))` or `((layer3 - layer2) - layer1)`.

Should fix #482 