### PR TITLE
Fixed visibility property for visuals with shadow

### DIFF
--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // We need to transfer "IsVisible" property from source to result
             // because result is now the root visual for both shadow and source.
             // Otherwise "IsVisible" property will be applied only to source.
-            MoveIsVisibleProperty(context, source, result);
+            TransferIsVisibleProperty(context, source, result);
 
             // Check if ShadowOnly can be false
             if (!dropShadowEffect.IsShadowOnly.IsAlways(true))
@@ -272,13 +272,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             return result;
         }
 
-        static void MoveIsVisibleProperty(TranslationContext context, Visual source, Visual target)
+        static void TransferIsVisibleProperty(TranslationContext context, Visual source, Visual target)
         {
-            // Here we are moving default value of "IsVisible" to target
+            // Here we are transfering default value of "IsVisible" to target
             target.IsVisible = source.IsVisible;
             source.IsVisible = null;
 
-            // Here we are moving "isVisible" animation to target
+            // Here we are transfering "isVisible" animation to target
             foreach (var animator in source.Animators.ToList())
             {
                 if (animator.AnimatedProperty != nameof(source.IsVisible))

--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 }
                 else
                 {
-                    throw new ArgumentException("IsVisible animation should be keyframe of expression");
+                    throw new ArgumentException("IsVisible animation should be KeyFrameAnimation_ or ExpressionAnimation");
                 }
 
                 source.StopAnimation(animator.AnimatedProperty);

--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -274,6 +274,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         static void MoveIsVisibleProperty(TranslationContext context, Visual source, Visual target)
         {
+            // Here we are moving default value of "IsVisible" to target
+            target.IsVisible = source.IsVisible;
+            source.IsVisible = null;
+
             // Here we are moving "isVisible" animation to target
             foreach (var animator in source.Animators.ToList())
             {
@@ -297,10 +301,6 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
                 source.StopAnimation(animator.AnimatedProperty);
             }
-
-            // Here we are moving default value of "IsVisible" to target
-            target.IsVisible = source.IsVisible;
-            source.IsVisible = null;
         }
 
         static Vector3 VectorFromRotationAndDistance(Rotation direction, double distance) =>

--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -242,6 +242,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             result.Size = size;
             result.Children.Add(blurResult);
 
+            // We need to transfer "IsVisible" property from source to result
+            // because result is now the root visual for both shadow and source.
+            // Otherwise "IsVisible" property will be applied only to source.
+            MoveIsVisibleProperty(context, source, result);
+
             // Check if ShadowOnly can be false
             if (!dropShadowEffect.IsShadowOnly.IsAlways(true))
             {
@@ -265,6 +270,37 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
 
             return result;
+        }
+
+        static void MoveIsVisibleProperty(TranslationContext context, Visual source, Visual target)
+        {
+            // Here we are moving "isVisible" animation to target
+            foreach (var animator in source.Animators.ToList())
+            {
+                if (animator.AnimatedProperty != nameof(source.IsVisible))
+                {
+                    continue;
+                }
+
+                if (animator.Animation is KeyFrameAnimation_)
+                {
+                    Animate.WithKeyFrame(context, target, animator.AnimatedProperty, (KeyFrameAnimation_)animator.Animation);
+                }
+                else if (animator.Animation is ExpressionAnimation)
+                {
+                    Animate.WithExpression(target, (ExpressionAnimation)animator.Animation, animator.AnimatedProperty);
+                }
+                else
+                {
+                    throw new ArgumentException("IsVisible animation should be keyframe of expression");
+                }
+
+                source.StopAnimation(animator.AnimatedProperty);
+            }
+
+            // Here we are moving default value of "IsVisible" to target
+            target.IsVisible = source.IsVisible;
+            source.IsVisible = null;
         }
 
         static Vector3 VectorFromRotationAndDistance(Rotation direction, double distance) =>


### PR DESCRIPTION
Fixing translation of shadow effect. If source of the shadow is not visible it does not make shadow disappear, so here I'm pushing `IsVisible` property up so that this property controls visibility of both, source and shadow visuals.