### PR TITLE
[LottieGen] Added workaround to make path animations playable even with different number of segments in keyframes

### DIFF
--- a/Lottie-Windows.sln
+++ b/Lottie-Windows.sln
@@ -133,6 +133,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Issues", "Issues", "{07D6DF
 		source\Issues\LT0042.md = source\Issues\LT0042.md
 		source\Issues\LT0043.md = source\Issues\LT0043.md
 		source\Issues\LT0044.md = source\Issues\LT0044.md
+		source\Issues\LT0045.md = source\Issues\LT0045.md
 		source\Issues\LV0001.md = source\Issues\LV0001.md
 		source\Issues\LV0002.md = source\Issues\LV0002.md
 		source\Issues\LV0003.md = source\Issues\LV0003.md

--- a/LottieGen/LottieGen.sln
+++ b/LottieGen/LottieGen.sln
@@ -88,6 +88,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Issues", "Issues", "{BDB88D
 		..\source\Issues\LT0042.md = ..\source\Issues\LT0042.md
 		..\source\Issues\LT0043.md = ..\source\Issues\LT0043.md
 		..\source\Issues\LT0044.md = ..\source\Issues\LT0044.md
+		..\source\Issues\LT0045.md = ..\source\Issues\LT0045.md
 		..\source\Issues\LV0001.md = ..\source\Issues\LV0001.md
 		..\source\Issues\LV0002.md = ..\source\Issues\LV0002.md
 		..\source\Issues\LV0003.md = ..\source\Issues\LV0003.md

--- a/source/Issues/LT0045.md
+++ b/source/Issues/LT0045.md
@@ -1,0 +1,13 @@
+[comment]: # (name:PathAnimationHasDifferentNumberOfSegments)
+[comment]: # (text:Path animation has different number of segments.)
+
+# Lottie-Windows Warning LT0045
+
+One of the path animations has different number of segments for different keyframes. Windows Composition API
+can't animate in this case, so Lottie-Windows added zero-length segments to some keyframs to make number of segments
+the same among all keyframes.
+
+## Resources
+
+* [Lottie-Windows repository](https://aka.ms/lottie)
+* [Questions and feedback via Github](https://github.com/windows-toolkit/Lottie-Windows/issues)

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -74,6 +74,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 return original;
             }
 
+            original.Context.Issues.PathAnimationHasDifferentNumberOfSegments();
+
             var populatePathGeometry = (PathGeometry pathGeometry) => {
                 List<BezierSegment> segments = pathGeometry.BezierSegments.ToList();
 

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             original.Context.Issues.PathAnimationHasDifferentNumberOfSegments();
 
-            var populatePathGeometry = (PathGeometry pathGeometry) => {
+            Func<PathGeometry, PathGeometry> populatePathGeometry = (PathGeometry pathGeometry) => {
                 List<BezierSegment> segments = pathGeometry.BezierSegments.ToList();
 
                 while (segments.Count < maxSegments)

--- a/source/LottieToWinComp/Paths.cs
+++ b/source/LottieToWinComp/Paths.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
                 else if (context.ObjectFactory.IsUapApiAvailable(nameof(PathKeyFrameAnimation), versionDependentFeatureDescription: "Path animation"))
                 {
                     // PathKeyFrameAnimation was introduced in 6 but was unreliable until 11.
-                    Animate.Path(context, path, fillType, geometry, nameof(geometry.Path), nameof(geometry.Path));
+                    Animate.Path(context, PopulatePathGeometriesToTheSameSize(path), fillType, geometry, nameof(geometry.Path), nameof(geometry.Path));
                     isPathApplied = true;
                 }
             }
@@ -61,6 +61,40 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             }
 
             return result;
+        }
+
+        static TrimmedAnimatable<PathGeometry> PopulatePathGeometriesToTheSameSize(TrimmedAnimatable<PathGeometry> original)
+        {
+            int maxSegments = Math.Max(original.KeyFrames.Select(x => x.Value.BezierSegments.Count).Max(), original.InitialValue.BezierSegments.Count);
+            int minSegments = Math.Min(original.KeyFrames.Select(x => x.Value.BezierSegments.Count).Min(), original.InitialValue.BezierSegments.Count);
+
+            // If all PathGeometry objects have the same number of segments -> Composition API can animate this.
+            if (minSegments == maxSegments)
+            {
+                return original;
+            }
+
+            var populatePathGeometry = (PathGeometry pathGeometry) => {
+                List<BezierSegment> segments = pathGeometry.BezierSegments.ToList();
+
+                while (segments.Count < maxSegments)
+                {
+                    var p = segments.Last().ControlPoint1;
+                    segments.Add(new BezierSegment(p, p, p, p));
+                }
+
+                return new PathGeometry(new Sequence<BezierSegment>(segments.AsEnumerable()), pathGeometry.IsClosed);
+            };
+
+            // If some PathGeometry ogjects have different number of segments -> Composition API can't animate this,
+            // we are using a workaround: populate path geometries to the same size, with the 0-length segments at the end.
+            var newKeyFrames = new List<KeyFrame<PathGeometry>>();
+            foreach (var keyframe in original.KeyFrames)
+            {
+                newKeyFrames.Add(new KeyFrame<PathGeometry>(keyframe.Frame, populatePathGeometry(keyframe.Value), keyframe.SpatialBezier, keyframe.Easing));
+            }
+
+            return new TrimmedAnimatable<PathGeometry>(original.Context, populatePathGeometry(original.InitialValue), newKeyFrames);
         }
 
         // If the given path is equivalent to a static path with an animated offset, convert

--- a/source/LottieToWinComp/TranslationIssues.cs
+++ b/source/LottieToWinComp/TranslationIssues.cs
@@ -126,6 +126,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
         internal void MatteLayerIsNeverVisible() => Report("LT0044", "One of the matte layers is never visible. It may be unintentional.");
 
+        internal void PathAnimationHasDifferentNumberOfSegments() => Report("LT0045", "Path animation has different number of segments for different keyframes.");
+
         void Report(string code, string description)
         {
             _issues.Add((code, description));


### PR DESCRIPTION
Some animations can't be played in Lottie-Windows because of WinComp Api limitation: number of segments in path animation should be the same for all keyframes, but After Effects supports animation with any number of segments.

Added a workaround to make number of segments equal for all the keyframes by adding 0-length segments to the path at the end. It may result in a little bit different animation from what you see in After Effects.

#493 
