### PR TITLE
Fixed gradient brush offset for rectangle geometry

### DIFF
--- a/source/LottieToWinComp/Brushes.cs
+++ b/source/LottieToWinComp/Brushes.cs
@@ -439,7 +439,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             // so that its value can be used in expression animation of property itself.
             string sourcePropertyName = propertyName + "Source";
             obj.Properties.InsertVector2(sourcePropertyName, ConvertTo.Vector2(value.InitialValue));
-            Animate.Vector2(context, value, obj, sourcePropertyName);
+
+            if (value.IsAnimated)
+            {
+                Animate.Vector2(context, value, obj, sourcePropertyName);
+            }
 
             // Create expression that offsets source property by origin offset.
             WinCompData.Expressions.Vector2 expression = offset.IsAnimated ?
@@ -518,10 +522,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var startPoint = Optimizer.TrimAnimatable(context, gradient.StartPoint);
             var endPoint = Optimizer.TrimAnimatable(context, gradient.EndPoint);
 
-            var startPointValue = AnimateVector2WithOriginOffsetOrGetValue(context, result, nameof(result.EllipseCenter), startPoint);
-            if (startPointValue is not null)
+            if (startPoint.IsAnimated)
             {
-                result.EllipseCenter = startPointValue!;
+                Animate.Vector2(context, startPoint, result, nameof(result.EllipseCenter));
+            }
+            else
+            {
+                result.EllipseCenter = ConvertTo.Vector2(startPoint.InitialValue);
             }
 
             if (endPoint.IsAnimated)

--- a/source/LottieToWinComp/ExpressionFactory.cs
+++ b/source/LottieToWinComp/ExpressionFactory.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
         internal static readonly Scalar MaxTStartTEnd = Max(MyTStart, MyTEnd);
         internal static readonly Scalar MinTStartTEnd = Min(MyTStart, MyTEnd);
         internal static readonly Vector2 HalfMySize = MySize / Vector2(2, 2);
-        internal static readonly Vector2 GeometryHalfSize = NamedVector2("geometry", "Size") / Vector2(2, 2);
+        internal static readonly Vector2 GeometryOffset = NamedVector2("geometry", "Offset");
+        internal static readonly Vector2 GeometryPosition = NamedVector2("geometry", "Position");
         internal static readonly Color AnimatedColorWithAnimatedOpacity =
             ColorAsVector4MultipliedByOpacities(MyColor, new[] { MyOpacity });
 

--- a/source/LottieToWinComp/Rectangles.cs
+++ b/source/LottieToWinComp/Rectangles.cs
@@ -319,10 +319,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var height = size.InitialValue.Y;
             var trimOffsetDegrees = (width / (2 * (width + height))) * 360;
 
-            // If offset is not animated then other computations for fill brush can be optimized.
-            context.LayerContext.OriginOffset = size.IsAnimated ?
-                new OriginOffsetContainer(geometry, ExpressionFactory.GeometryHalfSize) :
-                new OriginOffsetContainer(geometry, ConvertTo.Vector2(size.InitialValue / 2));
+            context.LayerContext.OriginOffset = GetOriginOffsetContainer(geometry, size, position);
 
             Shapes.TranslateAndApplyShapeContextWithTrimOffset(
                 context,
@@ -414,10 +411,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             var initialHeight = height.InitialValue;
             var trimOffsetDegrees = (initialWidth / (2 * (initialWidth + initialHeight))) * 360;
 
-            // If offset is not animated then other computations for fill brush can be optimized.
-            context.LayerContext.OriginOffset = width.IsAnimated || height.IsAnimated ?
-                new OriginOffsetContainer(geometry, ExpressionFactory.GeometryHalfSize) :
-                new OriginOffsetContainer(geometry, ConvertTo.Vector2(width.InitialValue / 2, height.InitialValue / 2));
+            context.LayerContext.OriginOffset = GetOriginOffsetContainerXY(geometry, width, height, position);
 
             Shapes.TranslateAndApplyShapeContextWithTrimOffset(
                 context,
@@ -427,6 +421,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
 
             compositionRectangle.SetDescription(context, () => rectangle.Name);
             compositionRectangle.Geometry.SetDescription(context, () => $"{rectangle.Name}.RectangleGeometry");
+        }
+
+        static OriginOffsetContainer GetOriginOffsetContainer(
+            RectangleOrRoundedRectangleGeometry geometry,
+            in TrimmedAnimatable<Vector3> size,
+            in TrimmedAnimatable<Vector3> position)
+        {
+            return size.IsAnimated || position.IsAnimated ?
+                new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ExpressionFactory.GeometryPosition : ExpressionFactory.GeometryOffset)) :
+                new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ConvertTo.Vector2(position.InitialValue) : InitialOffset(size, position)));
+        }
+
+        static OriginOffsetContainer GetOriginOffsetContainerXY(
+            RectangleOrRoundedRectangleGeometry geometry,
+            in TrimmedAnimatable<double> width,
+            in TrimmedAnimatable<double> height,
+            in TrimmedAnimatable<Vector3> position)
+        {
+            return width.IsAnimated || height.IsAnimated || position.IsAnimated ?
+                new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ExpressionFactory.GeometryPosition : ExpressionFactory.GeometryOffset)) :
+                new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ConvertTo.Vector2(position.InitialValue) : InitialOffset(width, height, position)));
         }
 
         public static CanvasGeometry CreateWin2dRectangleGeometry(

--- a/source/LottieToWinComp/Rectangles.cs
+++ b/source/LottieToWinComp/Rectangles.cs
@@ -428,6 +428,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             in TrimmedAnimatable<Vector3> size,
             in TrimmedAnimatable<Vector3> position)
         {
+            // Note: Current implementation of Windows Composition API behaves differently for Rounded Rectangle and regular Rectangle geometry.
+            // In first case we need to offset the inner content (e.g. gradient) by position only, and in second case by position and half the size (total offset).
             return size.IsAnimated || position.IsAnimated ?
                 new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ExpressionFactory.GeometryPosition : ExpressionFactory.GeometryOffset)) :
                 new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ConvertTo.Vector2(position.InitialValue) : InitialOffset(size, position)));
@@ -439,6 +441,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.LottieToWinComp
             in TrimmedAnimatable<double> height,
             in TrimmedAnimatable<Vector3> position)
         {
+            // Note: Current implementation of Windows Composition API behaves differently for Rounded Rectangle and regular Rectangle geometry.
+            // In first case we need to offset the inner content (e.g. gradient) by position only, and in second case by position and half the size (total offset).
             return width.IsAnimated || height.IsAnimated || position.IsAnimated ?
                 new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ExpressionFactory.GeometryPosition : ExpressionFactory.GeometryOffset)) :
                 new OriginOffsetContainer(geometry, -(geometry.IsRoundedRectangle ? ConvertTo.Vector2(position.InitialValue) : InitialOffset(width, height, position)));

--- a/source/WinCompData/Expressions/Vector2.cs
+++ b/source/WinCompData/Expressions/Vector2.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie.WinCompData.Expressions
 
         public static Vector2 operator -(Vector2 left, Vector2 right) => new Subtract(left, right);
 
+        public static Vector2 operator -(Vector2 value) => new Subtract(Vector2(0, 0), value);
+
         public static Vector2 operator +(Vector2 left, Vector2 right) => new Add(left, right);
 
         public static Vector2 operator *(Scalar left, Vector2 right) => new ScalarMultiply(left, right);


### PR DESCRIPTION
We've already have a fix for this, but turned out that it had some flaws: https://github.com/CommunityToolkit/Lottie-Windows/pull/450

- Current implementation of WinComp API behaves in a different way for Rounded Rectangle geometry and regular Rectangle Geometry. So I added an additional check for this. 
- Previous implementation didn't take into account position of the rectangle.
- Radial gradient behaves in a different way than linear gradient, so it doesn't need the offset at all.