### PR TITLE
[LottieGen] Refactored effects, added cache for factories

### DIFF
--- a/source/Lottie/Instantiator.cs
+++ b/source/Lottie/Instantiator.cs
@@ -1066,15 +1066,34 @@ namespace CommunityToolkit.WinUI.Lottie
                 return result;
             }
 
-            IEnumerable<Wd.CompositionEffectSourceParameter> sources;
+            // Create and initialize the effect brush.
+            var effectBrush = GetCompositionEffectFactory(obj.GetEffectFactory()).CreateBrush();
+            result = CacheAndInitializeCompositionObject(obj, effectBrush);
+
+            // Set the sources.
+            foreach (var source in obj.GetEffectFactory().Effect.Sources)
+            {
+                result.SetSourceParameter(source.Name, GetCompositionBrush(obj.GetSourceParameter(source.Name)));
+            }
+
+            StartAnimations(obj, result);
+            return result;
+        }
+
+        Wc.CompositionEffectFactory GetCompositionEffectFactory(Wd.CompositionEffectFactory obj)
+        {
+            if (GetExisting<Wc.CompositionEffectFactory>(obj, out var result))
+            {
+                return result;
+            }
+
             IGraphicsEffect graphicsEffect;
 
-            var wdEffect = obj.GetEffect();
-            switch (wdEffect.Type)
+            switch (obj.Effect.Type)
             {
                 case Wd.Mgce.GraphicsEffectType.CompositeEffect:
                     {
-                        var effect = (Wd.Mgce.CompositeEffect)wdEffect;
+                        var effect = (Wd.Mgce.CompositeEffect)obj.Effect;
 
                         // Create the effect.
                         var resultEffect = new Mgce.CompositeEffect
@@ -1088,32 +1107,21 @@ namespace CommunityToolkit.WinUI.Lottie
                         }
 
                         graphicsEffect = resultEffect;
-                        sources = effect.Sources;
                     }
 
                     break;
                 case Wd.Mgce.GraphicsEffectType.GaussianBlurEffect:
                     {
-                        var effect = (Wd.Mgce.GaussianBlurEffect)wdEffect;
+                        var effect = (Wd.Mgce.GaussianBlurEffect)obj.Effect;
 
                         // Create the effect.
                         var resultEffect = new Mgce.GaussianBlurEffect();
 
-                        if (effect.BlurAmount.HasValue)
-                        {
-                            resultEffect.BlurAmount = effect.BlurAmount.Value;
-                        }
+                        resultEffect.BlurAmount = effect.BlurAmount;
+
+                        resultEffect.Source = new Wc.CompositionEffectSourceParameter(effect.Sources.First().Name);
 
                         graphicsEffect = resultEffect;
-                        if (effect.Source is null)
-                        {
-                            sources = Array.Empty<Wd.CompositionEffectSourceParameter>();
-                        }
-                        else
-                        {
-                            resultEffect.Source = new Wc.CompositionEffectSourceParameter(effect.Source.Name);
-                            sources = new[] { effect.Source };
-                        }
                     }
 
                     break;
@@ -1121,18 +1129,11 @@ namespace CommunityToolkit.WinUI.Lottie
                     throw new InvalidOperationException();
             }
 
-            // Create and initialize the effect brush.
-            var effectBrush = _c.CreateEffectFactory(graphicsEffect).CreateBrush();
-            result = CacheAndInitializeCompositionObject(obj, effectBrush);
+            var factory = _c.CreateEffectFactory(graphicsEffect);
 
-            // Set the sources.
-            foreach (var source in sources)
-            {
-                result.SetSourceParameter(source.Name, GetCompositionBrush(obj.GetSourceParameter(source.Name)));
-            }
+            Cache(obj, factory);
 
-            StartAnimations(obj, result);
-            return result;
+            return factory;
         }
 
         Wc.CompositionSpriteShape GetCompositionSpriteShape(Wd.CompositionSpriteShape obj)

--- a/source/LottieToWinComp/CompositionObjectFactory.cs
+++ b/source/LottieToWinComp/CompositionObjectFactory.cs
@@ -288,7 +288,8 @@ namespace CommunityToolkit.WinUI.Lottie.LottieToWinComp
 
         internal CompositionSurfaceBrush CreateSurfaceBrush(ICompositionSurface surface) => _compositor.CreateSurfaceBrush(surface);
 
-        internal CompositionEffectFactory CreateEffectFactory(GraphicsEffectBase effect) => _compositor.CreateEffectFactory(effect);
+        // Get cached factory instead of creating from compositor.
+        internal CompositionEffectFactory CreateEffectFactory(GraphicsEffectBase effect) => CompositionEffectFactory.GetFactoryCached(effect);
 
         // Call this when consuming a feature that is only available in UAP versions > 7.
         void ConsumeVersionFeature(uint uapVersion)

--- a/source/LottieToWinComp/Effects.cs
+++ b/source/LottieToWinComp/Effects.cs
@@ -115,6 +115,8 @@ namespace CommunityToolkit.WinUI.Lottie.LottieToWinComp
                 return source;
             }
 
+            source.BorderMode = CompositionBorderMode.Soft;
+
             Debug.Assert(dropShadowEffect.IsEnabled, "Precondition");
             Debug.Assert(context is PreCompLayerContext || context is ShapeLayerContext, "Precondition");
 
@@ -403,15 +405,13 @@ namespace CommunityToolkit.WinUI.Lottie.LottieToWinComp
 
             var surfaceBrush = factory.CreateSurfaceBrush(visualSurface);
 
-            var effect = new WinCompData.Mgce.GaussianBlurEffect();
-
             var blurriness = Optimizer.TrimAnimatable(context, gaussianBlurEffect.Blurriness);
             if (blurriness.IsAnimated)
             {
                 context.Issues.AnimatedLayerEffectParameters("Gaussian blur");
             }
 
-            effect.BlurAmount = ConvertTo.Float(blurriness.InitialValue / 10.0);
+            var effect = new WinCompData.Mgce.GaussianBlurEffect(ConvertTo.Float(blurriness.InitialValue / 3.33), new CompositionEffectSourceParameter("source"));
 
             // We only support HorizontalAndVertical blur dimension.
             var blurDimensions = Optimizer.TrimAnimatable(context, gaussianBlurEffect.BlurDimensions);
@@ -425,8 +425,6 @@ namespace CommunityToolkit.WinUI.Lottie.LottieToWinComp
             {
                 context.Issues.UnsupportedLayerEffectParameter("gaussian blur", "blur dimension", value.Value.ToString());
             }
-
-            effect.Source = new CompositionEffectSourceParameter("source");
 
             var effectBrush = factory.CreateEffectFactory(effect).CreateBrush();
             effectBrush.SetSourceParameter("source", surfaceBrush);

--- a/source/LottieToWinComp/Masks.cs
+++ b/source/LottieToWinComp/Masks.cs
@@ -434,11 +434,7 @@ namespace CommunityToolkit.WinUI.Lottie.LottieToWinComp
             destinationVisualSurface.SourceOffset = ConvertTo.Vector2(offset);
             var destinationVisualSurfaceBrush = objectFactory.CreateSurfaceBrush(destinationVisualSurface);
 
-            var compositeEffect = new CompositeEffect();
-            compositeEffect.Mode = compositeMode;
-
-            compositeEffect.Sources.Add(new CompositionEffectSourceParameter("destination"));
-            compositeEffect.Sources.Add(new CompositionEffectSourceParameter("source"));
+            var compositeEffect = new CompositeEffect(compositeMode, new List<CompositionEffectSourceParameter>(new CompositionEffectSourceParameter[] { new CompositionEffectSourceParameter("destination"), new CompositionEffectSourceParameter("source") }));
 
             var compositionEffectFactory = objectFactory.CreateEffectFactory(compositeEffect);
             var effectBrush = compositionEffectFactory.CreateBrush();

--- a/source/UIData/Tools/ObjectGraph.cs
+++ b/source/UIData/Tools/ObjectGraph.cs
@@ -217,6 +217,9 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                 case CompositionObjectType.Vector4KeyFrameAnimation:
                     VisitVector4KeyFrameAnimation((Vector4KeyFrameAnimation)obj, node);
                     break;
+                case CompositionObjectType.CompositionEffectFactory:
+                    VisitCompositionEffectFactory((CompositionEffectFactory)obj, node);
+                    break;
                 default:
                     throw new InvalidOperationException();
             }
@@ -664,33 +667,22 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
             return true;
         }
 
+        bool VisitCompositionEffectFactory(CompositionEffectFactory obj, T node)
+        {
+            return VisitCompositionObject(obj, node);
+        }
+
         bool VisitCompositionEffectBrush(CompositionEffectBrush obj, T node)
         {
             VisitCompositionBrush(obj, node);
 
-            var effect = obj.GetEffect();
+            var effectFactory = obj.GetEffectFactory();
 
-            switch (effect.Type)
+            Reference(node, effectFactory);
+
+            foreach (var source in effectFactory.Effect.Sources)
             {
-                case GraphicsEffectType.CompositeEffect:
-                    foreach (var source in ((CompositeEffect)effect).Sources)
-                    {
-                        Reference(node, obj.GetSourceParameter(source.Name));
-                    }
-
-                    break;
-                case GraphicsEffectType.GaussianBlurEffect:
-                    {
-                        var source = ((GaussianBlurEffect)effect).Source;
-                        if (source is not null)
-                        {
-                            Reference(node, obj.GetSourceParameter(source.Name));
-                        }
-                    }
-
-                    break;
-                default:
-                    throw new InvalidOperationException();
+                Reference(node, obj.GetSourceParameter(source.Name));
             }
 
             return true;

--- a/source/UIData/Tools/Stats.cs
+++ b/source/UIData/Tools/Stats.cs
@@ -151,6 +151,9 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     case CompositionObjectType.Vector4KeyFrameAnimation:
                         Vector4KeyFrameAnimationCount++;
                         break;
+                    case CompositionObjectType.CompositionEffectFactory:
+                        EffectFactoryCount++;
+                        break;
                     default:
                         throw new InvalidOperationException();
                 }
@@ -180,6 +183,8 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
         public int DropShadowCount { get; }
 
         public int EffectBrushCount { get; }
+
+        public int EffectFactoryCount { get; }
 
         public int EllipseGeometryCount { get; }
 

--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -956,15 +956,9 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.CSharp
             var effectVariable = "gaussianBlurEffect";
             builder.WriteLine($"var {effectVariable} = new GaussianBlurEffect();");
 
-            if (effect.BlurAmount.HasValue)
-            {
-                builder.WriteLine($"{effectVariable}.BlurAmount = {_s.Float(effect.BlurAmount.Value)};");
-            }
+            builder.WriteLine($"{effectVariable}.BlurAmount = {_s.Float(effect.BlurAmount)};");
 
-            if (effect.Source is not null)
-            {
-                builder.WriteLine($"{effectVariable}.Source = new CompositionEffectSourceParameter({_s.String(effect.Source.Name)});");
-            }
+            builder.WriteLine($"{effectVariable}.Source = new CompositionEffectSourceParameter({_s.String(effect.Sources.First().Name)});");
 
             return effectVariable;
         }

--- a/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
@@ -778,15 +778,9 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Cppwinrt
         {
             var effectVariable = "gaussianBlurEffect";
             builder.WriteLine($"auto {effectVariable} = winrt::make_self<GaussianBlurEffect>();");
-            if (effect.BlurAmount.HasValue)
-            {
-                builder.WriteLine($"{effectVariable}->BlurAmount({_s.Float(effect.BlurAmount.Value)});");
-            }
+            builder.WriteLine($"{effectVariable}->BlurAmount({_s.Float(effect.BlurAmount)});");
 
-            if (effect.Source is not null)
-            {
-                builder.WriteLine($"{effectVariable}->Source(CompositionEffectSourceParameter(L\"{effect.Source.Name}\"));");
-            }
+            builder.WriteLine($"{effectVariable}->Source(CompositionEffectSourceParameter(L\"{effect.Sources.First().Name}\"));");
 
             return $"*{effectVariable}";
         }

--- a/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cx/CxInstantiatorGenerator.cs
@@ -646,16 +646,10 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Cx
         {
             var effectVariable = "gaussianBlurEffect";
             builder.WriteLine($"ComPtr<GaussianBlurEffect> {effectVariable}(new GaussianBlurEffect());");
-            if (effect.BlurAmount.HasValue)
-            {
-                builder.WriteLine($"{effectVariable}->put_BlurAmount({_s.Float(effect.BlurAmount.Value)});");
-            }
+            builder.WriteLine($"{effectVariable}->put_BlurAmount({_s.Float(effect.BlurAmount)});");
 
-            if (effect.Source is not null)
-            {
-                builder.WriteLine($"auto sourceParameter = ref new CompositionEffectSourceParameter({_s.String(effect.Source.Name)});");
-                builder.WriteLine($"{effectVariable}->put_Source(reinterpret_cast<ABI::Windows::Graphics::Effects::IGraphicsEffectSource*>(sourceParameter));");
-            }
+            builder.WriteLine($"auto sourceParameter = ref new CompositionEffectSourceParameter({_s.String(effect.Sources.First().Name)});");
+            builder.WriteLine($"{effectVariable}->put_Source(reinterpret_cast<ABI::Windows::Graphics::Effects::IGraphicsEffectSource*>(sourceParameter));");
 
             return $"reinterpret_cast<Windows::Graphics::Effects::IGraphicsEffect^>({effectVariable}.Get())";
         }

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -16,6 +16,7 @@ using CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Tables;
 using CommunityToolkit.WinUI.Lottie.UIData.Tools;
 using CommunityToolkit.WinUI.Lottie.WinCompData;
 using CommunityToolkit.WinUI.Lottie.WinCompData.MetaData;
+using CommunityToolkit.WinUI.Lottie.WinCompData.Mgce;
 using CommunityToolkit.WinUI.Lottie.WinCompData.Mgcg;
 using Expr = CommunityToolkit.WinUI.Lottie.WinCompData.Expressions;
 using Mgce = CommunityToolkit.WinUI.Lottie.WinCompData.Mgce;

--- a/source/WinCompData/CompositionEffectBrush.cs
+++ b/source/WinCompData/CompositionEffectBrush.cs
@@ -13,12 +13,12 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
 #endif
     sealed class CompositionEffectBrush : CompositionBrush
     {
-        readonly GraphicsEffectBase _effect;
+        readonly CompositionEffectFactory _effectFactory;
         readonly Dictionary<string, CompositionBrush> _sourceParameters = new Dictionary<string, CompositionBrush>();
 
-        internal CompositionEffectBrush(GraphicsEffectBase effect)
+        internal CompositionEffectBrush(CompositionEffectFactory effectFactory)
         {
-            _effect = effect;
+            _effectFactory = effectFactory;
         }
 
         public CompositionBrush GetSourceParameter(string name) => _sourceParameters[name];
@@ -28,7 +28,7 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
             _sourceParameters.Add(name, source);
         }
 
-        public GraphicsEffectBase GetEffect() => _effect;
+        public CompositionEffectFactory GetEffectFactory() => _effectFactory;
 
         public override CompositionObjectType Type => CompositionObjectType.CompositionEffectBrush;
     }

--- a/source/WinCompData/CompositionEffectFactory.cs
+++ b/source/WinCompData/CompositionEffectFactory.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime;
+
 using CommunityToolkit.WinUI.Lottie.WinCompData.Mgce;
 
 namespace CommunityToolkit.WinUI.Lottie.WinCompData
@@ -19,12 +24,28 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
             _effect = effect;
         }
 
-        public CompositionEffectBrush CreateBrush()
+        private static IList<CompositionEffectFactory> _effectFactoryCache = new List<CompositionEffectFactory>();
+
+        public static CompositionEffectFactory GetFactoryCached(GraphicsEffectBase effect)
         {
-            return new CompositionEffectBrush(_effect);
+            var found = _effectFactoryCache.Where(f => f.Effect.Equals(effect)).ToList();
+            var cached = found.Count == 0 ? null : found.First();
+
+            if (cached is null)
+            {
+                cached = new CompositionEffectFactory(effect);
+                _effectFactoryCache.Add(cached);
+            }
+
+            return cached!;
         }
 
-        public GraphicsEffectBase GetEffect() => _effect;
+        public CompositionEffectBrush CreateBrush()
+        {
+            return new CompositionEffectBrush(this);
+        }
+
+        public GraphicsEffectBase Effect => _effect;
 
         /// <inheritdoc/>
         public override CompositionObjectType Type => CompositionObjectType.CompositionEffectFactory;

--- a/source/WinCompData/CompositionEffectSourceParameter.cs
+++ b/source/WinCompData/CompositionEffectSourceParameter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace CommunityToolkit.WinUI.Lottie.WinCompData
 {
     [MetaData.UapVersion(2)]
@@ -16,5 +18,20 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
         }
 
         public string Name { get; }
+
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is CompositionEffectSourceParameter))
+            {
+                return false;
+            }
+
+            return ((CompositionEffectSourceParameter)obj).Name.Equals(Name);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<string>.Default.GetHashCode(Name);
+        }
     }
 }

--- a/source/WinCompData/Mgce/CompositeEffect.cs
+++ b/source/WinCompData/Mgce/CompositeEffect.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using CommunityToolkit.WinUI.Lottie.WinCompData.Mgc;
 
 namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
@@ -12,10 +13,56 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 #endif
     sealed class CompositeEffect : GraphicsEffectBase
     {
-        public CanvasComposite Mode { get; set; }
+        public CompositeEffect(CanvasComposite mode, IList<CompositionEffectSourceParameter> sources)
+        {
+            Mode = mode;
+            _sources = sources.ToList();
+        }
 
-        public IList<CompositionEffectSourceParameter> Sources { get; } = new List<CompositionEffectSourceParameter>();
+        public CanvasComposite Mode { get; }
+
+        private List<CompositionEffectSourceParameter> _sources;
+
+        public override IReadOnlyList<CompositionEffectSourceParameter> Sources => _sources.AsReadOnly();
 
         public override GraphicsEffectType Type => GraphicsEffectType.CompositeEffect;
+
+        public override bool Equals(object? obj)
+        {
+            if (!(obj is CompositeEffect))
+            {
+                return false;
+            }
+
+            var other = (CompositeEffect)obj;
+
+            if (other.Mode != Mode)
+            {
+                return false;
+            }
+
+            if (other.Sources.Count != Sources.Count)
+            {
+                return false;
+            }
+
+            foreach (var source in Sources)
+            {
+                if (!other.Sources.Contains(source))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1419366798;
+            hashCode = (hashCode * -1521134295) + Mode.GetHashCode();
+            hashCode = (hashCode * -1521134295) + _sources.Sum(x => x.GetHashCode());
+            return hashCode;
+        }
     }
 }

--- a/source/WinCompData/Mgce/GaussianBlurEffect.cs
+++ b/source/WinCompData/Mgce/GaussianBlurEffect.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 {
@@ -11,11 +13,48 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 #endif
     sealed class GaussianBlurEffect : GraphicsEffectBase
     {
-        // Default is 3.0.
-        public float? BlurAmount { get; set; }
+        public GaussianBlurEffect(float blurAmount, CompositionEffectSourceParameter source)
+        {
+            BlurAmount = blurAmount;
+            _source = source;
+        }
 
-        public CompositionEffectSourceParameter? Source { get; set; }
+        public float BlurAmount { get; }
+
+        private CompositionEffectSourceParameter _source;
+
+        public override IReadOnlyList<CompositionEffectSourceParameter> Sources => new List<CompositionEffectSourceParameter>() { _source };
 
         public override GraphicsEffectType Type => GraphicsEffectType.GaussianBlurEffect;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is GaussianBlurEffect))
+            {
+                return false;
+            }
+
+            var other = (GaussianBlurEffect)obj;
+
+            if (other.BlurAmount != BlurAmount)
+            {
+                return false;
+            }
+
+            if (other.Sources.Count != Sources.Count)
+            {
+                return false;
+            }
+
+            return _source?.Equals(((GaussianBlurEffect)obj)._source) ?? false;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 593574215;
+            hashCode = (hashCode * -1521134295) + BlurAmount.GetHashCode();
+            hashCode = (hashCode * -1521134295) + _source?.GetHashCode() ?? 0;
+            return hashCode;
+        }
     }
 }

--- a/source/WinCompData/Mgce/GaussianBlurEffect.cs
+++ b/source/WinCompData/Mgce/GaussianBlurEffect.cs
@@ -27,7 +27,7 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 
         public override GraphicsEffectType Type => GraphicsEffectType.GaussianBlurEffect;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is GaussianBlurEffect))
             {

--- a/source/WinCompData/Mgce/GraphicsEffectBase.cs
+++ b/source/WinCompData/Mgce/GraphicsEffectBase.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 {
     /// <summary>
@@ -13,6 +16,8 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgce
 #endif
     abstract class GraphicsEffectBase
     {
+        public abstract IReadOnlyList<CompositionEffectSourceParameter> Sources { get; }
+
         public abstract GraphicsEffectType Type { get; }
     }
 }


### PR DESCRIPTION
Lottie-Windows was previously generating one factory per each effect. I refactored the code a little bit so that we can reference same factory for multiple EffectBrushes which will reduce number of factories being created. OS does in fact have it's own cache for effects, so this change does not increase performance, just decreases generated code size.

Also small fix: fixed blur + shadow radius scaling, After Effects blur of radius `R` corresponds to Windows blur of radius `R / 3.33`