### PR TITLE
Use base64 string instead of array of bytes for CSharp code gen.

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -966,11 +966,10 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.CSharp
         /// <inheritdoc/>
         protected override void WriteByteArrayField(CodeBuilder builder, string fieldName, IReadOnlyList<byte> bytes)
         {
-            builder.WriteLine($"static readonly byte[] {fieldName} = new byte[]");
-            builder.OpenScope();
-            builder.WriteByteArrayLiteral(bytes, maximumColumns: 115);
-            builder.UnIndent();
-            builder.WriteLine("};");
+            string base64 = Convert.ToBase64String(bytes.ToArray());
+            builder.WriteLine($"static readonly string {fieldName}_base64 = ");
+            builder.WriteLongStringLiteral(base64, 115);
+            builder.WriteLine(";");
         }
 
         void WriteAnimatedVisualInvalidatedEvent(CodeBuilder builder)
@@ -1002,7 +1001,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.CSharp
                 switch (n.LoadedImageSurfaceType)
                 {
                     case LoadedImageSurface.LoadedImageSurfaceType.FromStream:
-                        builder.WriteLine($"{n.FieldName} = LoadedImageSurface.StartLoadFromStream({n.BytesFieldName}.AsBuffer().AsStream().AsRandomAccessStream());");
+                        builder.WriteLine($"{n.FieldName} = LoadedImageSurface.StartLoadFromStream(Convert.FromBase64String({n.BytesFieldName}_base64).AsBuffer().AsStream().AsRandomAccessStream());");
                         break;
                     case LoadedImageSurface.LoadedImageSurfaceType.FromUri:
                         builder.WriteComment(n.Comment);

--- a/source/UIDataCodeGen/CodeGen/CodeBuilder.cs
+++ b/source/UIDataCodeGen/CodeGen/CodeBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -383,6 +384,31 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
             }
 
             WriteLine(bytesLines[i]);
+        }
+
+        /// <summary>
+        /// Write long string literal on separate lines.
+        /// </summary>
+        /// <param name="value">String to write.</param>
+        /// <param name="maximumColumns">Width limit of the output line.</param>
+        internal void WriteLongStringLiteral(string value, int maximumColumns)
+        {
+            int start = 0;
+            int len = maximumColumns - 1 - (_indentCount * IndentSize);
+            while (start < value.Length)
+            {
+                int end = Math.Min(start + len, value.Length);
+                if (end == value.Length)
+                {
+                    WriteLine($"\"{value.Substring(start, end - start)}\"");
+                }
+                else
+                {
+                    WriteLine($"\"{value.Substring(start, end - start)}\" +");
+                }
+
+                start += len;
+            }
         }
 
         static IEnumerable<string> BytesToBytesList(IEnumerable<byte> bytes, int maximumWidth)


### PR DESCRIPTION
This change should reduce size of embeded images that are exported as bytes arrays currently by a factor of 3, by exporting them as base64. For c#  only for now, because it is unclear which base64 API to use for winrt and cxx