### PR TITLE
Fixed codegen to produce correct WinUI3 code

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
+++ b/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
@@ -114,6 +114,6 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
         /// </summary>
         public Version WinUIVersion { get; set; }
 
-        public bool ImplementCreateAndDestroyMethods => WinUIVersion >= Version.Parse("2.7");
+        public bool ImplementCreateAndDestroyMethods => WinUIVersion >= Version.Parse("2.7") && WinUIVersion < Version.Parse("3.0");
     }
 }


### PR DESCRIPTION
There were some problems with generating code for WinUI3, a lot of namespaces were wrong (Microsoft vs Windows) and also some types are not available for WinUI3. Fixed so that LottieGen now work correctly for WinUI3 as well.