### PR TITLE
Fixed IAnimatedVisual impl line for WinUI 2.8 (+fixed 2.7 -> 2.8)

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
+++ b/source/UIDataCodeGen/CodeGen/CodegenConfiguration.cs
@@ -114,6 +114,6 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
         /// </summary>
         public Version WinUIVersion { get; set; }
 
-        public bool ImplementCreateAndDestroyMethods => WinUIVersion >= Version.Parse("2.7") && WinUIVersion < Version.Parse("3.0");
+        public bool ImplementCreateAndDestroyMethods => WinUIVersion >= Version.Parse("2.8") && WinUIVersion < Version.Parse("3.0");
     }
 }

--- a/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/Cppwinrt/CppwinrtInstantiatorGenerator.cs
@@ -507,10 +507,8 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Cppwinrt
             {
                 builder.WriteLine($"winrt::{_animatedVisualTypeName2},");
             }
-            else
-            {
-                builder.WriteLine($"winrt::{_animatedVisualTypeName},");
-            }
+
+            builder.WriteLine($"winrt::{_animatedVisualTypeName},");
 
             builder.WriteLine($"IClosable>");
             builder.UnIndent();

--- a/source/UIDataCodeGen/CodeGen/IAnimatedVisualInfo.cs
+++ b/source/UIDataCodeGen/CodeGen/IAnimatedVisualInfo.cs
@@ -26,7 +26,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
 
         /// <summary>
         /// Do we need to implement CreateAnimations and DestroyAnimations method.
-        /// Available after WinUI 2.7 with new interface IAnimatedVisual2.
+        /// Available after WinUI 2.8 with new interface IAnimatedVisual2.
         /// </summary>
         bool ImplementCreateAndDestroyMethods { get; }
 


### PR DESCRIPTION
For CppWinRT we should declare all the interfaces that we want to implement. Previously we declared IAnimatedVisual2 without IAnimatedVisual which caused animations to not show up.
Also changed min version of WinUI from 2.7 to 2.8 for IAnimatedVisual2 because it became finally available only in 2.8.