### PR TITLE
Fix wrong variable name with GenerateDependencyObject parameter

### DIFF
--- a/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
+++ b/source/UIDataCodeGen/CodeGen/CSharp/CSharpInstantiatorGenerator.cs
@@ -714,7 +714,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.CSharp
                     builder.WriteLine($"{(firstSeen ? "else " : string.Empty)}if (propertyName == {_s.String(prop.BindingName)})");
                     firstSeen = true;
                     builder.OpenScope();
-                    builder.WriteLine($"_theme{prop.BindingName} = value;");
+                    builder.WriteLine($"{(SourceInfo.GenerateDependencyObject ? string.Empty : "_theme")}{prop.BindingName} = value;");
                     builder.CloseScope();
                 }
 


### PR DESCRIPTION
According to source\UIDataCodeGen\CodeGen\CSharp\CSharpInstantiatorGenerator.cs line 376

```c#
            // Add fields for each of the theme properties.
            // Not needed if generating a DependencyObject - the values will be stored in DependencyPropertys.
            if (!SourceInfo.GenerateDependencyObject)
            {
                foreach (var prop in SourceInfo.SourceMetadata.PropertyBindings)
                {
                    var defaultValue = GetDefaultPropertyBindingValue(prop);

                    WriteInitializedField(builder, ExposedType(prop), $"_theme{prop.BindingName}", _s.VariableInitialization($"c_theme{prop.BindingName}"));
                }
            }
```

If used GenerateDependencyObject parameter there is no variable call "_theme{prop.BindingName}", when write the SetColorProperty function, it should change the variable name