### PR TITLE
Update IsChildOf graph walk in LayersGraph.cs

### DIFF
--- a/source/Lottie/Loader.cs
+++ b/source/Lottie/Loader.cs
@@ -90,7 +90,7 @@ namespace CommunityToolkit.WinUI.Lottie
                             LottieCompositionReader.Options.IgnoreMatchNames,
                             out var readerIssues);
 
-                    if (lottieComposition is not null)
+                    if (lottieComposition is not null && options.HasFlag(LottieVisualOptions.Optimize))
                     {
                         lottieComposition = LottieMergeOptimizer.Optimize(lottieComposition);
                     }

--- a/source/LottieData/Optimization/LayersGraph.cs
+++ b/source/LottieData/Optimization/LayersGraph.cs
@@ -11,6 +11,18 @@ namespace CommunityToolkit.WinUI.Lottie.LottieData.Optimization
     /// <summary>
     /// Represents directed acyclic graph of layer groups.
     /// Node1 is child of Node2 iff they have time ranges that intersect and Node1 goes after Node2 in z-order.
+    ///
+    ///                         +Z
+    /// |---------------------------------------------------|
+    ///      |--Node1--|
+    ///             |---Node2---|                              Time -->
+    ///                                |----Node3----|
+    /// |---------------------------------------------------|
+    ///                         -Z
+    ///
+    /// In this example Node1 is a child of Node2, but not of Node3.
+    /// Nodes can have multiple parents. Optimizations can be made to graphs that don't overlap in
+    /// time, which is often the case when a single Lottie file contains multiple animations.
     /// </summary>
 #if PUBLIC_LottieData
     public

--- a/source/LottieData/Optimization/LayersGraph.cs
+++ b/source/LottieData/Optimization/LayersGraph.cs
@@ -57,12 +57,12 @@ namespace CommunityToolkit.WinUI.Lottie.LottieData.Optimization
 
             private bool IsChildOf(GraphNode node, HashSet<GraphNode> visited)
             {
-                if (visited.Contains(node))
+                if (visited.Contains(this))
                 {
                     return false;
                 }
 
-                visited.Add(node);
+                visited.Add(this);
 
                 foreach (var parent in Parents)
                 {

--- a/source/LottieData/Optimization/LayersGraph.cs
+++ b/source/LottieData/Optimization/LayersGraph.cs
@@ -66,7 +66,7 @@ namespace CommunityToolkit.WinUI.Lottie.LottieData.Optimization
 
                 foreach (var parent in Parents)
                 {
-                    if (parent.Equals(node) || parent.IsChildOf(node))
+                    if (parent.Equals(node) || parent.IsChildOf(node, visited))
                     {
                         return true;
                     }


### PR DESCRIPTION
It looks like the recursive graph walk in LayersGraph.cs was intended to use the visited set of nodes as part of its traversal. In a quick test, I saw a Lottie json file load time go from 2 minutes down to 15 seconds.

Discovered by running the Visual Studio profiler over the Lottie Viewer