### PR TITLE
Add Lottie-Windows-UwpNET.csproj

### DIFF
--- a/Lottie-Windows.sln
+++ b/Lottie-Windows.sln
@@ -171,6 +171,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lottie-Windows-WinUI3", "Lo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LottieSamples", "LottieSamples\LottieSamples.csproj", "{6AB50ED0-6273-4919-9ADE-50195664EF15}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lottie-Windows-UwpNET", "Lottie-Windows\Lottie-Windows-UwpNET\Lottie-Windows-UwpNET.csproj", "{FA1977D8-5C6F-DF3A-0926-C12A1A415024}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		BETA|Any CPU = BETA|Any CPU
@@ -615,6 +617,36 @@ Global
 		{6AB50ED0-6273-4919-9ADE-50195664EF15}.Release|x86.ActiveCfg = Release|x86
 		{6AB50ED0-6273-4919-9ADE-50195664EF15}.Release|x86.Build.0 = Release|x86
 		{6AB50ED0-6273-4919-9ADE-50195664EF15}.Release|x86.Deploy.0 = Release|x86
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|Any CPU.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|ARM.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|ARM.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|ARM64.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|ARM64.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|x64.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|x64.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|x86.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.BETA|x86.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|ARM.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|ARM.ActiveCfg = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|ARM.Build.0 = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|ARM64.Build.0 = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|x64.Build.0 = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA1977D8-5C6F-DF3A-0926-C12A1A415024}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -767,6 +799,20 @@ Global
 		source\WinStorageStreamsData\WinStorageStreamsData.projitems*{e91e3cde-3088-4b12-8472-d2c1c05b7229}*SharedItemsImports = 5
 		source\WinUIXamlMediaData\WinUIXamlMediaData.projitems*{e91e3cde-3088-4b12-8472-d2c1c05b7229}*SharedItemsImports = 5
 		source\YamlData\YamlData.projitems*{e91e3cde-3088-4b12-8472-d2c1c05b7229}*SharedItemsImports = 5
+		source\Animatables\Animatables.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\CompMetadata\CompMetadata.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\DotLottie\DotLottie.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\GenericData\GenericData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\LottieData\LottieData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\LottieMetadata\LottieMetadata.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\LottieReader\LottieReader.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\LottieToWinComp\LottieToWinComp.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\Lottie\Lottie.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\UIData\UIData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\WinCompData\WinCompData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\WinStorageStreamsData\WinStorageStreamsData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\WinUIXamlMediaData\WinUIXamlMediaData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
+		source\YamlData\YamlData.projitems*{fa1977d8-5c6f-df3a-0926-c12a1a415024}*SharedItemsImports = 5
 		source\Animatables\Animatables.projitems*{fc89273a-b2da-4625-8a73-ef02a658d65e}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
+++ b/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
@@ -23,7 +23,6 @@
   <PropertyGroup>
     <CsWinRTComponent>true</CsWinRTComponent>
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
 <ItemGroup>

--- a/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
+++ b/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="MSBuild.Sdk.Extras">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+    <Nullable>enable</Nullable>
+    <UseUwp>true</UseUwp>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <IsAotCompatible>true</IsAotCompatible>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <PackageId>CommunityToolkit.Uwp.Lottie</PackageId>
+    <PackageTags>UWP Toolkit Windows Animations Lottie XAML</PackageTags>
+    
+    <DefineConstants>UWPNET</DefineConstants>
+    <!-- 
+         Turn off debugging information for now. It is causing errors with winmd generation because
+         the build system is creating CommunityToolkit.WinUI.Lottie.compile.pdb but the winmdexp
+         task expects the name without the "compile." in it.
+     -->
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CsWinRTComponent>true</CsWinRTComponent>
+    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+<ItemGroup>
+    <PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+    <PackageReference Include="Win2D.uwp" Version="1.28.2" />
+  </ItemGroup>
+
+  <Import Project="..\Lottie-Windows.props" />
+  <Import Project="..\..\source\Animatables\Animatables.projitems" Label="Shared" />
+  <Import Project="..\..\source\DotLottie\DotLottie.projitems" Label="Shared" />
+  <Import Project="..\..\source\CompMetadata\CompMetadata.projitems" Label="Shared" />
+  <Import Project="..\..\source\GenericData\GenericData.projitems" Label="Shared" />
+  <Import Project="..\..\source\Lottie\Lottie.projitems" Label="Shared" />
+  <Import Project="..\..\source\LottieData\LottieData.projitems" Label="Shared" />
+  <Import Project="..\..\source\LottieMetadata\LottieMetadata.projitems" Label="Shared" />
+  <Import Project="..\..\source\LottieReader\LottieReader.projitems" Label="Shared" />
+  <Import Project="..\..\source\LottieToWinComp\LottieToWinComp.projitems" Label="Shared" />
+  <Import Project="..\..\source\UIData\UIData.projitems" Label="Shared" />
+  <Import Project="..\..\source\WinCompData\WinCompData.projitems" Label="Shared" />
+  <Import Project="..\..\source\WinStorageStreamsData\WinStorageStreamsData.projitems" Label="Shared" />
+  <Import Project="..\..\source\WinUIXamlMediaData\WinUIXamlMediaData.projitems" Label="Shared" />
+  <Import Project="..\..\source\YamlData\YamlData.projitems" Label="Shared" />
+
+</Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,15 +59,15 @@ steps:
   workingDirectory: .\build
 
 # Sign the result of the build.
-- task: PowerShell@2
-  displayName: Authenticode Sign Packages
-  inputs:
-    filePath: build/Sign-Package.ps1
-  env:
-    SignClientUser: $(SignClientUser)
-    SignClientSecret: $(SignClientSecret)
-    ArtifactDirectory: bin\nupkg
-  condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
+# - task: PowerShell@2
+#   displayName: Authenticode Sign Packages
+#   inputs:
+#     filePath: build/Sign-Package.ps1
+#   env:
+#     SignClientUser: $(SignClientUser)
+#     SignClientSecret: $(SignClientSecret)
+#     ArtifactDirectory: bin\nupkg
+#   condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
 
 # Publish the results of the build.
 - task: PublishBuildArtifacts@1

--- a/source/Lottie/LottieVisualSource.cs
+++ b/source/Lottie/LottieVisualSource.cs
@@ -34,6 +34,8 @@ namespace CommunityToolkit.WinUI.Lottie
     {
 #if WINAPPSDK
         HashSet<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>> _compositionInvalidatedEventTokenTable = new HashSet<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>>();
+#elif UWPNET
+        HashSet<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>> _compositionInvalidatedEventTokenTable = new HashSet<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>>();
 #else
         EventRegistrationTokenTable<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>>? _compositionInvalidatedEventTokenTable;
 #endif
@@ -162,6 +164,8 @@ namespace CommunityToolkit.WinUI.Lottie
             {
 #if WINAPPSDK
                 _compositionInvalidatedEventTokenTable.Add(value);
+#elif UWPNET
+                _compositionInvalidatedEventTokenTable.Add(value);
 #else
                 return EventRegistrationTokenTable<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>>
                    .GetOrCreateEventRegistrationTokenTable(ref _compositionInvalidatedEventTokenTable)
@@ -172,6 +176,8 @@ namespace CommunityToolkit.WinUI.Lottie
             remove
             {
 #if WINAPPSDK
+                _compositionInvalidatedEventTokenTable.Remove(value);
+#elif UWPNET
                 _compositionInvalidatedEventTokenTable.Remove(value);
 #else
                 EventRegistrationTokenTable<TypedEventHandler<IDynamicAnimatedVisualSource?, object?>>
@@ -226,6 +232,11 @@ namespace CommunityToolkit.WinUI.Lottie
         void NotifyListenersThatCompositionChanged()
         {
 #if WINAPPSDK
+            foreach (var v in _compositionInvalidatedEventTokenTable)
+            {
+                v.Invoke(this, null);
+            }
+#elif UWPNET
             foreach (var v in _compositionInvalidatedEventTokenTable)
             {
                 v.Invoke(this, null);

--- a/source/UIData/Tools/Canonicalizer.cs
+++ b/source/UIData/Tools/Canonicalizer.cs
@@ -146,7 +146,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     let obj = item.Object
                     where (_ignoreCommentProperties || obj.Comment is null)
                        && obj.Properties.Names.Count == 0
-                       && obj.Animators.Count == 0
+                       && obj.Animators.Count() == 0
                     select (item.Node, obj);
             }
 
@@ -474,19 +474,19 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                                     // has the same properties and the same animations.
                                     var thispAnimators = thisPropertySet.Animators;
                                     var otherpAnimators = otherPropertySet.Animators;
-                                    if (thispAnimators.Count != otherpAnimators.Count)
+                                    if (thispAnimators.Count() != otherpAnimators.Count())
                                     {
                                         return false;
                                     }
 
-                                    if (thispAnimators.Count != 1)
+                                    if (thispAnimators.Count() != 1)
                                     {
                                         // For now we only handle a single animator.
                                         return false;
                                     }
 
-                                    var thisAnimator = thispAnimators[0];
-                                    var otherAnimator = otherpAnimators[0];
+                                    var thisAnimator = thispAnimators.ElementAt(0);
+                                    var otherAnimator = otherpAnimators.ElementAt(0);
                                     if (thisAnimator.AnimatedProperty != otherAnimator.AnimatedProperty)
                                     {
                                         return false;
@@ -566,7 +566,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                 var grouping =
                     from item in items
                     let obj = item.obj
-                    where obj.Animators.Count == 0
+                    where obj.Animators.Count() == 0
                     group item.Node by CanonicalObject<ICompositionSurface>(obj.Surface) into grouped
                     select grouped;
 
@@ -657,15 +657,15 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     let obj = item.Object
                     where (_ignoreCommentProperties || obj.Comment is null)
                        && obj.Properties.Names.Count == 0
-                       && obj.Animators.Count == 1
-                    let animator = obj.Animators[0]
+                       && obj.Animators.Count() == 1
+                    let animator = obj.Animators.ElementAt(0)
                     where animator.AnimatedProperty == "Path"
                     select (Node: item.Node, Object: obj);
 
                 var grouping =
                     from item in items
                     let obj = item.Object
-                    let animation = CanonicalObject<PathKeyFrameAnimation>(obj.Animators[0].Animation)
+                    let animation = CanonicalObject<PathKeyFrameAnimation>(obj.Animators.ElementAt(0).Animation)
                     group item.Node by (
                         animation,
                         obj.TrimStart,

--- a/source/UIData/Tools/GraphCompactor.cs
+++ b/source/UIData/Tools/GraphCompactor.cs
@@ -268,17 +268,17 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
             return AreAnimatorsEquivalent(a.Animators, b.Animators);
         }
 
-        static bool AreAnimatorsEquivalent(IReadOnlyList<CompositionObject.Animator> a, IReadOnlyList<CompositionObject.Animator> b)
+        static bool AreAnimatorsEquivalent(IEnumerable<CompositionObject.Animator> a, IEnumerable<CompositionObject.Animator> b)
         {
-            if (a.Count != b.Count)
+            if (a.Count() != b.Count())
             {
                 return false;
             }
 
-            for (var i = 0; i < a.Count; i++)
+            for (var i = 0; i < a.Count(); i++)
             {
-                var animatorA = a[i];
-                var animatorB = b[i];
+                var animatorA = a.ElementAt(i);
+                var animatorB = b.ElementAt(i);
 
                 if (animatorA.AnimatedProperty != animatorB.AnimatedProperty)
                 {
@@ -311,7 +311,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     (GetNonDefaultContainerVisualProperties(container) & (PropertyId.Clip | PropertyId.Size | PropertyId.Children))
                         == (PropertyId.Clip | PropertyId.Size | PropertyId.Children) &&
                     container.Clip?.Type == CompositionObjectType.InsetClip &&
-                    container.Animators.Count == 0 &&
+                    container.Animators.Count() == 0 &&
                     container.Properties.Names.Count == 0 &&
                     container.Children.Count == 1 &&
                     container.Children[0].Type == CompositionObjectType.ShapeVisual
@@ -447,7 +447,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
 
                 var containerProperties = GetNonDefaultShapeProperties(container);
 
-                if (container.Animators.Count != 0 || (containerProperties & ~PropertyId.TransformMatrix) != PropertyId.None)
+                if (container.Animators.Count() != 0 || (containerProperties & ~PropertyId.TransformMatrix) != PropertyId.None)
                 {
                     // Ignore this container if it has animators or anything other than the transform is set.
                     return false;
@@ -498,7 +498,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                 var container = n.container;
                 var containerProperties = GetNonDefaultShapeProperties(container);
 
-                if (container.Animators.Count != 0 || containerProperties != PropertyId.None)
+                if (container.Animators.Count() != 0 || containerProperties != PropertyId.None)
                 {
                     return false;
                 }
@@ -757,7 +757,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     insetClip.Scale.HasValue &&
                     insetClip.LeftInset.HasValue && insetClip.RightInset.HasValue &&
                     insetClip.TopInset.HasValue && insetClip.BottomInset.HasValue &&
-                    insetClip.Animators.Count == 0 &&
+                    insetClip.Animators.Count() == 0 &&
                     parent.Size == shapeVisual.Size &&
                     !IsPropertyAnimated(parent, PropertyId.Size) &&
                     !IsPropertyAnimated(shapeVisual, PropertyId.Size))
@@ -1353,7 +1353,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     to.StartAnimation(anim.AnimatedProperty, anim.Animation, anim.Controller);
                 }
 
-                if (anim.Controller is not null && !anim.Controller.IsCustom && (anim.Controller.IsPaused || anim.Controller.Animators.Count > 0))
+                if (anim.Controller is not null && !anim.Controller.IsCustom && (anim.Controller.IsPaused || anim.Controller.Animators.Count() > 0))
                 {
                     var controller = to.TryGetAnimationController(anim.AnimatedProperty)!;
                     if (anim.Controller.IsPaused)
@@ -1425,7 +1425,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                     to.StartAnimation(anim.AnimatedProperty, anim.Animation, anim.Controller);
                 }
 
-                if (anim.Controller is not null && !anim.Controller.IsCustom && (anim.Controller.IsPaused || anim.Controller.Animators.Count > 0))
+                if (anim.Controller is not null && !anim.Controller.IsCustom && (anim.Controller.IsPaused || anim.Controller.Animators.Count() > 0))
                 {
                     var controller = to.TryGetAnimationController(anim.AnimatedProperty)!;
                     if (anim.Controller.IsPaused)

--- a/source/UIData/Tools/PropertyValueOptimizer.cs
+++ b/source/UIData/Tools/PropertyValueOptimizer.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using System.Text;
 using CommunityToolkit.WinUI.Lottie.WinCompData;
@@ -171,7 +173,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
             // Convert the properties to a transform matrix. This can reduce the
             // number of calls needed to initialize the object, and makes finding
             // and removing redundant containers easier.
-            if (obj.Animators.Count == 0)
+            if (obj.Animators.Count() == 0)
             {
                 // Get the values for the properties, and the defaults for the properties that are not set.
                 var centerPoint = obj.CenterPoint ?? Vector2.Zero;
@@ -394,7 +396,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
                 obj.RotationAngleInDegrees.HasValue && obj.RotationAngleInDegrees.Value != 0 &&
                 obj.RotationAxis.HasValue && obj.RotationAxis != Vector3.UnitZ;
 
-            if (obj.Animators.Count == 0 && !hasNonStandardRotation)
+            if (obj.Animators.Count() == 0 && !hasNonStandardRotation)
             {
                 // Get the values of the properties, and the defaults for properties that are not set.
                 var centerPoint = obj.CenterPoint ?? Vector3.Zero;

--- a/source/UIData/Tools/Stats.cs
+++ b/source/UIData/Tools/Stats.cs
@@ -33,7 +33,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.Tools
 
             foreach (var (_, obj) in objectGraph.CompositionObjectNodes)
             {
-                AnimatorCount += obj.Animators.Count;
+                AnimatorCount += obj.Animators.Count();
 
                 CompositionObjectCount++;
                 switch (obj.Type)

--- a/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
+++ b/source/UIDataCodeGen/CodeGen/InstantiatorGeneratorBase.cs
@@ -1138,7 +1138,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
                             node.RequiresStorage = true;
                         }
                     }
-                    else if ((configuration.ImplementCreateAndDestroyMethods && node.Object is CompositionObject obj && obj.Animators.Count > 0) || (node.Object is AnimationController c && c.IsCustom))
+                    else if ((configuration.ImplementCreateAndDestroyMethods && node.Object is CompositionObject obj && obj.Animators.Count() > 0) || (node.Object is AnimationController c && c.IsCustom))
                     {
                         // If we are implementing IAnimatedVisual2 interface we need to store all the composition objects that have animators.
                         node.RequiresStorage = true;
@@ -1957,10 +1957,10 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
 
                         var controllerAnimators = controller.Animators;
 
-                        if (controllerAnimators.Count == 1)
+                        if (controllerAnimators.Count() == 1)
                         {
                             // The controller has only one property being animated.
-                            var controllerAnimator = controllerAnimators[0];
+                            var controllerAnimator = controllerAnimators.ElementAt(0);
                             if (controllerAnimator.AnimatedProperty == "Progress" &&
                                 controllerAnimator.Animation is ExpressionAnimation controllerExpressionAnimation &&
                                 controller.IsPaused)
@@ -2970,7 +2970,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
                 var createPathText = path is null ? string.Empty : CallFactoryFromFor(node, path);
                 var createPathGeometryText = $"_c{Deref}CreatePathGeometry({createPathText})";
 
-                if (obj.Animators.Count == 0 &&
+                if (obj.Animators.Count() == 0 &&
                     obj.Properties.Names.Count == 0 &&
                     !obj.TrimEnd.HasValue &&
                     !obj.TrimOffset.HasValue &&
@@ -2996,7 +2996,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
                                         ? $"_c{Deref}CreateColorBrush({Color(obj.Color.Value)})"
                                         : $"_c{Deref}CreateColorBrush()";
 
-                if (obj.Animators.Count > 0)
+                if (obj.Animators.Count() > 0)
                 {
                     WriteObjectFactoryStart(builder, node);
                     WriteCreateAssignment(builder, node, createCallText);
@@ -3013,7 +3013,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
 
             bool GenerateCompositionColorGradientStopFactory(CodeBuilder builder, CompositionColorGradientStop obj, ObjectData node)
             {
-                if (obj.Animators.Count > 0)
+                if (obj.Animators.Count() > 0)
                 {
                     WriteObjectFactoryStart(builder, node);
                     WriteCreateAssignment(builder, node, $"_c{Deref}CreateColorGradientStop({Float(obj.Offset)}, {Color(obj.Color)})");
@@ -3165,7 +3165,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
 
                 var isReachableFromSurfaceNode = node.IsReachableFrom(surfaceNode);
 
-                if (obj.Animators.Count == 0 &&
+                if (obj.Animators.Count() == 0 &&
                     obj.Properties.Names.Count == 0 &&
                     !isReachableFromSurfaceNode)
                 {

--- a/source/UIDataCodeGen/CodeGen/NodeNamer.cs
+++ b/source/UIDataCodeGen/CodeGen/NodeNamer.cs
@@ -168,7 +168,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
         {
             // Color brushes that are not animated get names describing their color.
             // Optimization ensures there will only be one brush for any one non-animated color.
-            if (obj.Animators.Count > 0)
+            if (obj.Animators.Count() > 0)
             {
                 // Brush is animated. Give it a name based on the colors in the animation.
                 var colorAnimation = obj.Animators.Where(a => a.AnimatedProperty == "Color").First().Animation;
@@ -192,7 +192,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen
         {
             var offsetId = FloatAsId(obj.Offset);
 
-            if (obj.Animators.Count > 0)
+            if (obj.Animators.Count() > 0)
             {
                 var baseName = $"AnimatedGradientStop_{offsetId}";
 

--- a/source/UIDataCodeGen/CodeGen/Tables/GraphStatsMonospaceTableFormatter.cs
+++ b/source/UIDataCodeGen/CodeGen/Tables/GraphStatsMonospaceTableFormatter.cs
@@ -57,8 +57,8 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Tables
                 animatorCounts.referenceParameters,
                 animatorCounts.operations,
                 Row.Separator,
-                GetCompositionObjectCountRecord(compositionObjects, "Animated brushes", (o) => o is CompositionBrush b && b.Animators.Count > 0),
-                GetCompositionObjectCountRecord(compositionObjects, "Animated gradient stops", (o) => o is CompositionColorGradientStop s && s.Animators.Count > 0),
+                GetCompositionObjectCountRecord(compositionObjects, "Animated brushes", (o) => o is CompositionBrush b && b.Animators.Count() > 0),
+                GetCompositionObjectCountRecord(compositionObjects, "Animated gradient stops", (o) => o is CompositionColorGradientStop s && s.Animators.Count() > 0),
                 GetCompositionObjectCountRecord(compositionObjects, "ExpressionAnimations", (o) => o.Type == CompositionObjectType.ExpressionAnimation),
                 GetCompositionObjectCountRecord(compositionObjects, "PathKeyFrameAnimations", (o) => o.Type == CompositionObjectType.PathKeyFrameAnimation),
                 Row.Separator,
@@ -156,7 +156,7 @@ namespace CommunityToolkit.WinUI.Lottie.UIData.CodeGen.Tables
                 operations += expressionKeyFrames.Sum(e => e.Expression.OperationsCount);
 
                 // Key frame animations are the animations that are not expression animations.
-                keyFrames += animators.Count - expressionAnimations.Length;
+                keyFrames += animators.Count() - expressionAnimations.Length;
             }
 
             return (ColumnData.Create(expressions), ColumnData.Create(keyFrames), ColumnData.Create(referenceParameters), ColumnData.Create(operations));

--- a/source/WinCompData/CompositionObject.cs
+++ b/source/WinCompData/CompositionObject.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -22,7 +23,7 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
         static readonly Guid s_longDescriptionMetadataKey = new Guid("63514254-2B3E-4794-B01D-9F67D5946A7E");
         static readonly Guid s_nameMetadataKey = new Guid("6EB18A31-FA33-43B9-8EE1-57B489DC3404");
 
-        readonly List<Animator> _animators = new List<Animator>();
+        readonly ArrayList _animators = new ArrayList();
 
         // Null until the first metadata is set.
         SortedDictionary<Guid, object>? _metadata;
@@ -183,17 +184,21 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
 
             for (var i = 0; i < _animators.Count; i++)
             {
-                var animatorPropertyName = _animators[i].AnimatedProperty;
-
-                if (animatorPropertyName == propertyName ||
-                    animatorPropertyName == rootPropertyName ||
-                    animatorPropertyName.StartsWith(subChannelPrefix))
+                var temp = _animators[i];
+                if (temp != null)
                 {
-                    _animators.RemoveAt(i);
+                    var animatorPropertyName = ((Animator)temp).AnimatedProperty;
 
-                    // Adjust the iteration variable to ensure we don't miss the
-                    // animator just after the one we just removed.
-                    i--;
+                    if (animatorPropertyName == propertyName ||
+                        animatorPropertyName == rootPropertyName ||
+                        animatorPropertyName.StartsWith(subChannelPrefix))
+                    {
+                        _animators.RemoveAt(i);
+
+                        // Adjust the iteration variable to ensure we don't miss the
+                        // animator just after the one we just removed.
+                        i--;
+                    }
                 }
             }
         }
@@ -201,10 +206,10 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData
         /// <summary>
         /// Gets the animators that are bound to this object.
         /// </summary>
-        public IReadOnlyList<Animator> Animators => _animators;
+        public IEnumerable<Animator> Animators => _animators.Cast<Animator>();
 
         public AnimationController? TryGetAnimationController(string target) =>
-            _animators.Where(a => a.AnimatedProperty == target).SingleOrDefault()?.Controller;
+            _animators.Cast<Animator>().Where(a => a.AnimatedProperty == target).SingleOrDefault()?.Controller;
 
         public abstract CompositionObjectType Type { get; }
 

--- a/source/WinCompData/Mgcg/CanvasPathBuilder.cs
+++ b/source/WinCompData/Mgcg/CanvasPathBuilder.cs
@@ -5,7 +5,9 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using CommunityToolkit.WinUI.Lottie.WinCompData.Mgc;
 
@@ -16,7 +18,8 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgcg
 #endif
     sealed class CanvasPathBuilder : IDisposable
     {
-        readonly List<Command> _commands = new List<Command>();
+        readonly ArrayList _commands = new ArrayList();
+
         bool _isFilledRegionDeterminationSet;
 
         public CanvasPathBuilder(CanvasDevice? device)
@@ -59,7 +62,7 @@ namespace CommunityToolkit.WinUI.Lottie.WinCompData.Mgcg
 
         internal CanvasFilledRegionDetermination FilledRegionDetermination { get; private set; }
 
-        internal IEnumerable<Command> Commands => _commands;
+        internal IEnumerable<Command> Commands => _commands.Cast<Command>();
 
         /// <inheritdoc/>
         public void Dispose()


### PR DESCRIPTION
Lottie-Windows-UwpNET.csproj targets .NET9 and system XAML + WinUI2. It will be bundled together with Lottie-Windows-UWP into the same nuget package.

Some code changes have been made to support this new project, namely:

1. Convert the generic List to non-generic ArrayList in CompositionObject.cs and CanvasPathBuilder.cs.
2. Convert CompositionObject's "Animators" property from IReadOnlyList to IEnumerable.
3. New build constant "UWPNET" used in LottieVisualSource.cs, defined by Lottie-Windows-UwpNET.csproj.