### PR TITLE
Switch UWPNET assembly name to CommunityToolkit.Uwp.Lottie

### DIFF
--- a/Lottie-Windows/Lottie-Windows-Uwp/Lottie-Windows-Uwp.csproj
+++ b/Lottie-Windows/Lottie-Windows-Uwp/Lottie-Windows-Uwp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>uap10.0.16299</TargetFramework>
     <OutputType>winmdobj</OutputType>
 
-
+    <AssemblyName>CommunityToolkit.WinUI.Lottie</AssemblyName>
     <PackageId>CommunityToolkit.Uwp.Lottie</PackageId>
     <PackageTags>UWP Toolkit Windows Animations Lottie XAML</PackageTags>
     

--- a/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
+++ b/Lottie-Windows/Lottie-Windows-UwpNET/Lottie-Windows-UwpNET.csproj
@@ -8,6 +8,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <IsAotCompatible>true</IsAotCompatible>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+
+    <AssemblyName>CommunityToolkit.Uwp.Lottie</AssemblyName>
     <PackageId>CommunityToolkit.Uwp.Lottie</PackageId>
     <PackageTags>UWP Toolkit Windows Animations Lottie XAML</PackageTags>
     
@@ -18,11 +20,6 @@
          task expects the name without the "compile." in it.
      -->
     <DebugType>none</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <CsWinRTComponent>true</CsWinRTComponent>
-    <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>
   </PropertyGroup>
 
 <ItemGroup>

--- a/Lottie-Windows/Lottie-Windows-WinUI3/Lottie-Windows-WinUI3.csproj
+++ b/Lottie-Windows/Lottie-Windows-WinUI3/Lottie-Windows-WinUI3.csproj
@@ -5,6 +5,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <OutputType>Library</OutputType>
     
+    <AssemblyName>CommunityToolkit.WinUI.Lottie</AssemblyName>
     <PackageId>CommunityToolkit.WinUI.Lottie</PackageId>
     <PackageTags>WinUI3 Toolkit Windows Animations Lottie XAML</PackageTags>
 

--- a/Lottie-Windows/Lottie-Windows.props
+++ b/Lottie-Windows/Lottie-Windows.props
@@ -3,7 +3,6 @@
   <PropertyGroup Label="Configuration">
 
     <RootNamespace>CommunityToolkit.WinUI.Lottie</RootNamespace>
-    <AssemblyName>CommunityToolkit.WinUI.Lottie</AssemblyName>
 
     <!-- Nuget props-->
     <Description>This library provides the LottieVisualSource which is consumed by the Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer to render Lottie JSON files.</Description>


### PR DESCRIPTION
If a consumer wants to use both UWPNET and WinUI3, the DLL names conflict since they're both "CommunityToolkit.WinUI.Lottie.dll". So rename the UWPNET one to CommunityToolkit.**Uwp**.Lottie.dll.

```<CsWinRTComponent>true</CsWinRTComponent>``` prevents the renaming, and it's not required for C# consumers so drop this as well.