### PR TITLE
Add WV2 reference in WinUI3 project

### DIFF
--- a/Lottie-Windows/Lottie-Windows-WinUI3/Lottie-Windows-WinUI3.csproj
+++ b/Lottie-Windows/Lottie-Windows-WinUI3/Lottie-Windows-WinUI3.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.5.1" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3240.44" PrivateAssets="all" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
   </ItemGroup>
 


### PR DESCRIPTION
The WinUI3 nuget's .pri file references WebView2Loader.dll which causes WebView2Loader.dll to be included into the appx package payload and breaks the build on consumer's end. 

This is due to an old bug in the WV2 nuget, which happens to exist in the version that WinAppSDK pulls in. So adding an explicit dependency to WV2 with a newer version fixes this issue.

Verified by building & generating nupkg and inspecting the .pri file produced - no more WebView2Loader.dll!