### PR TITLE
Update UWP namespace in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There are **two** options to integrate Lottie animations into your **WinUI 3** o
     ```xml
         ...
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-        xmlns:lottie="using:CommunityToolkit.Uwp.Lottie"
+        xmlns:lottie="using:CommunityToolkit.WinUI.Lottie"
         ...
         <muxc:AnimatedVisualPlayer>
             <lottie:LottieVisualSource UriSource="<asset path or web link to a json file>" />


### PR DESCRIPTION
Addressing #563 - both UWP and WinUI3 packages use the same "CommunityToolkit.WinUI.Lottie" namespace now so the UWP sample code is out of date. 

 